### PR TITLE
makes consistent use of tmp dirs for generated/downloaded files

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { BrowserContext, Page } from 'playwright-core';
-import { launch } from './launch';
+import { launch, sessionPath } from './launch';
 import { Dappwright, OfficialOptions } from './types';
 import { getWallet, WalletOptions } from './wallets/wallets';
 
@@ -8,7 +8,7 @@ export const bootstrap = async (
   browserName: string,
   { seed, password, showTestNets, ...launchOptions }: OfficialOptions & WalletOptions,
 ): Promise<[Dappwright, Page, BrowserContext]> => {
-  fs.rmSync('./dappwrightSession', { recursive: true, force: true });
+  fs.rmSync(sessionPath, { recursive: true, force: true });
   const { browserContext } = await launch(browserName, launchOptions);
   const wallet = await getWallet('metamask', browserContext);
   await wallet.setup({ seed, password, showTestNets });

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -1,3 +1,5 @@
+import os from 'os';
+import * as path from 'path';
 import playwright from 'playwright-core';
 
 import { DappwrightLaunchResponse, OfficialOptions } from './types';
@@ -6,6 +8,7 @@ import { getWallet, getWalletType } from './wallets/wallets';
 /**
  * Launch Playwright chromium instance with MetaMask plugin installed
  * */
+export const sessionPath = path.resolve(os.tmpdir(), 'dappwright', 'session');
 
 export async function launch(browserName: string, options: OfficialOptions): Promise<DappwrightLaunchResponse> {
   const wallet = getWalletType(options.wallet);
@@ -13,7 +16,7 @@ export async function launch(browserName: string, options: OfficialOptions): Pro
 
   const extensionPath = await wallet.download(options);
 
-  const browserContext = await playwright.chromium.launchPersistentContext('./dappwrightSession', {
+  const browserContext = await playwright.chromium.launchPersistentContext(sessionPath, {
     headless: false,
     args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`],
   });

--- a/src/wallets/metamask/setup/downloader.ts
+++ b/src/wallets/metamask/setup/downloader.ts
@@ -8,7 +8,7 @@ import os from 'os';
 import { OfficialOptions } from '../../../types';
 import { isNewerVersion } from './isNewerVersion';
 
-const defaultDirectory = path.resolve(os.tmpdir(), 'dappwright', 'metamask');
+export const defaultDirectory = path.resolve(os.tmpdir(), 'dappwright', 'metamask');
 
 export type Path =
   | string

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -1,5 +1,4 @@
 import { readdir } from 'fs/promises';
-import path from 'path';
 
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -9,6 +8,7 @@ import { Dappwright } from '../src/index';
 
 import { BrowserContext, Page } from 'playwright-core';
 import { MetaMaskWallet } from '../src/wallets/metamask/metamask';
+import { defaultDirectory } from '../src/wallets/metamask/setup/downloader';
 import deploy from './deploy';
 import { pause } from './utils';
 import { addNetworkTests } from './utils/addNetwork';
@@ -39,7 +39,7 @@ describe('dappwright', () => {
     await testPage.goto('http://localhost:8080/');
 
     // output version
-    const directory = path.resolve(__dirname, '..', 'metamask');
+    const directory = defaultDirectory;
     const files = await readdir(directory);
     console.log(`::set-output name=version::${files.pop().replace(/_/g, '.')}`);
   });


### PR DESCRIPTION
**Short description of work done**
many files were still showing up in the current directory after running. This was causing some messy commits in projects that consume this lib.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master