### PR TITLE
fix: Implements a dynamic way of reaching the homepage of a chrome extension

### DIFF
--- a/.changeset/few-melons-impress.md
+++ b/.changeset/few-melons-impress.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+Fixes extension url mismatch issue

--- a/src/wallets/coinbase/actions.ts
+++ b/src/wallets/coinbase/actions.ts
@@ -3,7 +3,6 @@ import { AddNetwork, AddToken } from '../..';
 import { waitForChromeState } from '../../helpers';
 import { performPopupAction } from '../metamask/actions';
 import { WalletOptions } from '../wallets';
-import { extensionUrl } from './coinbase';
 
 const goHome = async (page: Page): Promise<void> => {
   await page.getByTestId('portfolio-navigation-link').click();
@@ -80,7 +79,7 @@ export const addNetwork =
   async (options: AddNetwork): Promise<void> => {
     // Add network flow closes current screen and opens another, direct access is cleaner for now
     const settingsPage = await page.context().newPage();
-    await settingsPage.goto(`${extensionUrl}?internalPopUpRequest=true&action=addCustomNetwork`);
+    await settingsPage.goto(`${page.url()}?internalPopUpRequest=true&action=addCustomNetwork`);
     await settingsPage.getByTestId('custom-network-name-input').fill(options.networkName);
     await settingsPage.getByTestId('custom-network-rpc-url-input').fill(options.rpc);
     await settingsPage.getByTestId('custom-network-chain-id-input').fill(options.chainId.toString());

--- a/src/wallets/coinbase/coinbase.ts
+++ b/src/wallets/coinbase/coinbase.ts
@@ -1,4 +1,3 @@
-import { Page } from 'playwright-core';
 import { setup } from '../metamask/setup';
 import downloader from '../metamask/setup/downloader';
 import Wallet from '../wallet';
@@ -23,19 +22,13 @@ import {
   unlock,
 } from './actions';
 
-export const extensionUrl = 'chrome-extension://niockamnihbifmabjckhncfbggkcanme/index.html';
-
 export class CoinbaseWallet extends Wallet {
   static id = 'coinbase' as WalletIdOptions;
   static recommendedVersion = '3.0.4';
   static releasesUrl = 'https://api.github.com/repos/osis/coinbase-wallet-archive/releases';
-  static extensionUrl = extensionUrl;
+  static homePath = '/index.html';
 
   options: WalletOptions;
-
-  constructor(page: Page) {
-    super(page);
-  }
 
   // Extension Downloader
   static download = downloader(this.id, this.releasesUrl, this.recommendedVersion);

--- a/src/wallets/metamask/metamask.ts
+++ b/src/wallets/metamask/metamask.ts
@@ -1,4 +1,3 @@
-import { Page } from 'playwright-core';
 import Wallet from '../wallet';
 import { Step, WalletIdOptions, WalletOptions } from '../wallets';
 import {
@@ -27,13 +26,9 @@ export class MetaMaskWallet extends Wallet {
   static id = 'metamask' as WalletIdOptions;
   static recommendedVersion = '10.20.0';
   static releasesUrl = 'https://api.github.com/repos/metamask/metamask-extension/releases';
-  static extensionUrl = 'chrome-extension://pmlhcfhikiidanoeecddljgpcmipdkak/home.html';
+  static homePath = '/home.html';
 
   options: WalletOptions;
-
-  constructor(page: Page) {
-    super(page);
-  }
 
   // Extension Downloader
   static download = downloader(this.id, this.releasesUrl, this.recommendedVersion);

--- a/src/wallets/metamask/setup/downloader.ts
+++ b/src/wallets/metamask/setup/downloader.ts
@@ -53,7 +53,7 @@ export default (walletId: WalletIdOptions, releasesUrl: string, recommendedVersi
 
       console.log(''); // new line
 
-      EXTENSION_PATH = await download('v' + version, releasesUrl, downloadDir(walletId));
+      EXTENSION_PATH = await download(version, releasesUrl, downloadDir(walletId));
     } else {
       console.log(`Running tests on local ${walletId} build`);
     }
@@ -74,7 +74,7 @@ const download = async (version: string, releasesUrl: string, location: string):
   // eslint-disable-next-line no-console
   console.log('Downloading extension...');
 
-  const { filename, downloadUrl, tag } = await getGithubRelease(releasesUrl, version);
+  const { filename, downloadUrl, tag } = await getGithubRelease(releasesUrl, `v${version}`);
   const extractDestination = path.resolve(location, tag.replace(/\./g, '_'));
 
   // Clean if system tmp files are cleaned but dir structure can persist

--- a/src/wallets/wallet.ts
+++ b/src/wallets/wallet.ts
@@ -6,8 +6,6 @@ export default abstract class Wallet implements Dappwright {
   version: string;
   page: Page;
 
-  // abstract options: WalletOptions;
-
   constructor(page: Page) {
     this.page = page;
   }
@@ -16,7 +14,7 @@ export default abstract class Wallet implements Dappwright {
   static id: WalletIdOptions;
   static recommendedVersion: string;
   static releasesUrl: string;
-  static extensionUrl: string;
+  static homePath: string;
 
   // Extension downloader
   static download: (options: OfficialOptions) => Promise<string>;

--- a/src/wallets/wallets.ts
+++ b/src/wallets/wallets.ts
@@ -31,28 +31,29 @@ export const getWallet = async (id: WalletIdOptions, browserContext: BrowserCont
       // Wait for the wallet to pop up
       const page = await browserContext.waitForEvent('page', { timeout: 1000 });
       return new wallet(page);
-    } catch {
-      // Open the wallet manually if tab doesn't pop up
-      const page = await browserContext.newPage();
+    } catch {}
 
-      // Go to internal system page to list installed extensions
-      await page.goto('chrome://system/');
-      await page.waitForSelector('//button[@id="extensions-value-btn"]', { timeout: 5000 });
+    // Open the wallet manually if tab doesn't pop up
+    const page = await browserContext.newPage();
+
+    // Go to internal system page to list installed extensions
+    await page.goto('chrome://system/');
+
+    try {
+      await page.waitForSelector('//*[@id="extensions-value-btn"]', { timeout: 5000 });
       await page.getByRole('button', { name: 'Expand all…' }).click();
+    } catch {}
 
-      // Extract extension id
-      const extensionsEl = await page.waitForSelector('//*[@id="extensions-value"]');
-      const extensionsContext = (await extensionsEl.textContent()).split(/ : |\n/);
-      const walletNameIndex = extensionsContext.findIndex((context: string) =>
-        context.toLowerCase().includes(wallet.id),
-      );
-      const extensionId = extensionsContext[walletNameIndex - 1];
+    // Extract extension id
+    const extensionsEl = await page.waitForSelector('//*[@id="extensions-value"]');
+    const extensionsContext = (await extensionsEl.textContent()).split(/ : |\n/);
+    const walletNameIndex = extensionsContext.findIndex((context: string) => context.toLowerCase().includes(wallet.id));
+    const extensionId = extensionsContext[walletNameIndex - 1];
 
-      // Load extension homepage
-      await page.goto(`chrome-extension://${extensionId}${wallet.homePath}`);
+    // Load extension homepage
+    await page.goto(`chrome-extension://${extensionId}${wallet.homePath}`);
 
-      return new wallet(page);
-    }
+    return new wallet(page);
   }
 
   const page = browserContext.pages()[1];

--- a/src/wallets/wallets.ts
+++ b/src/wallets/wallets.ts
@@ -28,15 +28,33 @@ export const getWallet = async (id: WalletIdOptions, browserContext: BrowserCont
 
   if (browserContext.pages().length === 1) {
     try {
-      await browserContext.waitForEvent('page', { timeout: 1000 });
+      // Wait for the wallet to pop up
+      const page = await browserContext.waitForEvent('page', { timeout: 1000 });
+      return new wallet(page);
     } catch {
-      // Open the wallet if tab doesn't pop up automatically
+      // Open the wallet manually if tab doesn't pop up
       const page = await browserContext.newPage();
-      await page.goto(wallet.extensionUrl);
+
+      // Go to internal system page to list installed extensions
+      await page.goto('chrome://system/');
+      await page.waitForSelector('//button[@id="extensions-value-btn"]', { timeout: 5000 });
+      await page.getByRole('button', { name: 'Expand all…' }).click();
+
+      // Extract extension id
+      const extensionsEl = await page.waitForSelector('//*[@id="extensions-value"]');
+      const extensionsContext = (await extensionsEl.textContent()).split(/ : |\n/);
+      const walletNameIndex = extensionsContext.findIndex((context: string) =>
+        context.toLowerCase().includes(wallet.id),
+      );
+      const extensionId = extensionsContext[walletNameIndex - 1];
+
+      // Load extension homepage
+      await page.goto(`chrome-extension://${extensionId}${wallet.homePath}`);
+
+      return new wallet(page);
     }
   }
 
   const page = browserContext.pages()[1];
-
   return new wallet(page);
 };

--- a/src/wallets/wallets.ts
+++ b/src/wallets/wallets.ts
@@ -31,7 +31,9 @@ export const getWallet = async (id: WalletIdOptions, browserContext: BrowserCont
       // Wait for the wallet to pop up
       const page = await browserContext.waitForEvent('page', { timeout: 1000 });
       return new wallet(page);
-    } catch {}
+    } catch {
+      // Wallet has failed to pop up, move on
+    }
 
     // Open the wallet manually if tab doesn't pop up
     const page = await browserContext.newPage();
@@ -42,7 +44,9 @@ export const getWallet = async (id: WalletIdOptions, browserContext: BrowserCont
     try {
       await page.waitForSelector('//*[@id="extensions-value-btn"]', { timeout: 5000 });
       await page.getByRole('button', { name: 'Expand all…' }).click();
-    } catch {}
+    } catch {
+      // Chrome doesn't have enough information on the screen to show the expand button, move on
+    }
 
     // Extract extension id
     const extensionsEl = await page.waitForSelector('//*[@id="extensions-value"]');


### PR DESCRIPTION
### Summary

This implements a new way of dynamically extracting the chrome extension id of the chrome extensions in order to navigate to their respective home pages.

### Changes
- dappwright will navigate to the `chrome://system` page to extract a dynamically generated chrome id

### Issues
Closes #50 