### PR TITLE
fix: navigate home after coinbase setup

### DIFF
--- a/.changeset/honest-glasses-wonder.md
+++ b/.changeset/honest-glasses-wonder.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+navigate home after coinbase setup

--- a/src/wallets/coinbase/actions.ts
+++ b/src/wallets/coinbase/actions.ts
@@ -8,6 +8,10 @@ const goHome = async (page: Page): Promise<void> => {
   await page.getByTestId('portfolio-navigation-link').click();
 };
 
+export const navigateHome = async (page: Page): Promise<void> => {
+  await page.goto(page.url().split('?')[0]);
+};
+
 export async function getStarted(
   page: Page,
   {

--- a/src/wallets/coinbase/coinbase.ts
+++ b/src/wallets/coinbase/coinbase.ts
@@ -16,6 +16,7 @@ import {
   hasNetwork,
   importPK,
   lock,
+  navigateHome,
   sign,
   switchAccount,
   switchNetwork,
@@ -34,7 +35,7 @@ export class CoinbaseWallet extends Wallet {
   static download = downloader(this.id, this.releasesUrl, this.recommendedVersion);
 
   // Setup
-  defaultSetupSteps: Step<WalletOptions>[] = [getStarted];
+  defaultSetupSteps: Step<WalletOptions>[] = [getStarted, navigateHome];
   setup = setup(this.page, this.defaultSetupSteps);
 
   // Actions


### PR DESCRIPTION
Navigating to the homepage after the initial setup allows for follow up actions to have a good starting state when invoked in an overall test environment setup.

#### Example

```typescript
const [coinbase, page, context] = await dappwright.bootstrap("", {
    wallet: "coinbase",
    version: CoinbaseWallet.recommendedVersion,
    seed: process.env.DAPPWRIGHT_SEED,
  });

await coinbase.createAccount();
```

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master
