### PR TITLE
fix: adds missing await for coinbase accountSwitch & deleteNetwork clicks

### DIFF
--- a/.changeset/healthy-poets-act.md
+++ b/.changeset/healthy-poets-act.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+adds missing await for coinbase account switch click

--- a/.changeset/soft-keys-notice.md
+++ b/.changeset/soft-keys-notice.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+adds missing await for coinbase accountSwitch & deleteNetwork clicks

--- a/src/wallets/coinbase/actions.ts
+++ b/src/wallets/coinbase/actions.ts
@@ -117,7 +117,7 @@ export const deleteNetwork =
 
     // Search for network then click on the first result
     await page.getByTestId('network-list-search').fill(name);
-    (await page.waitForSelector('//div[@data-testid="list-"][1]//button')).click();
+    await (await page.waitForSelector('//div[@data-testid="list-"][1]//button')).click();
 
     await page.getByTestId('custom-network-delete').click();
     await goHome(page);
@@ -189,13 +189,15 @@ export const createAccount = (page: Page) => async (): Promise<void> => {
   } catch {
     // Ignore missing help prompt
   }
+
+  await waitForChromeState(page);
 };
 
 export const switchAccount =
   (page: Page) =>
   async (i: number): Promise<void> => {
     await page.getByTestId('portfolio-header--switcher-cell-pressable').click();
-    (
+    await (
       await page.waitForSelector(`(//button[@data-testid="wallet-switcher--wallet-item-cell-pressable"])[${i}]`)
     ).click();
   };


### PR DESCRIPTION
This fixes an issue where the switchAccount & deleteNetwork actions for Coinbase Wallet weren't waiting for the click to complete causing a race condition in certain scenarios.

### PR Checklist
- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master
