### PR TITLE
Add headless option to bootstrap 

### DIFF
--- a/src/launch.ts
+++ b/src/launch.ts
@@ -11,15 +11,19 @@ import { getWallet, getWalletType } from './wallets/wallets';
 export const sessionPath = path.resolve(os.tmpdir(), 'dappwright', 'session');
 
 export async function launch(browserName: string, options: OfficialOptions): Promise<DappwrightLaunchResponse> {
-  const wallet = getWalletType(options.wallet);
+  const { headless, ...officialOptions } = options;
+  const wallet = getWalletType(officialOptions.wallet);
   if (!wallet) throw new Error('Wallet not supported');
 
-  const extensionPath = await wallet.download(options);
+  const extensionPath = await wallet.download(officialOptions);
 
-  const browserContext = await playwright.chromium.launchPersistentContext(path.join(sessionPath, options.wallet), {
-    headless: true,
-    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`],
-  });
+  const browserContext = await playwright.chromium.launchPersistentContext(
+    path.join(sessionPath, officialOptions.wallet),
+    {
+      headless: headless ?? false,
+      args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`],
+    },
+  );
 
   return {
     wallet: await getWallet(wallet.id, browserContext),

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -17,7 +17,7 @@ export async function launch(browserName: string, options: OfficialOptions): Pro
   const extensionPath = await wallet.download(options);
 
   const browserContext = await playwright.chromium.launchPersistentContext(path.join(sessionPath, options.wallet), {
-    headless: false,
+    headless: true,
     args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`],
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type DappwrightConfig = Partial<{
 export type OfficialOptions = DappwrightBrowserLaunchArgumentOptions & {
   wallet: WalletIdOptions;
   version: 'latest' | string;
+  headless?: boolean;
 };
 
 export type DappwrightLaunchResponse = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide all required information
-->

**Short description of work done**

- Added `headless` options to bootstrap. It's needed to have the possibility to run the E2E test on different CI environments without installing virtual X env. Example:

![image](https://user-images.githubusercontent.com/1782530/216949215-0265eca5-8e8d-4505-b235-f1c1b2d38948.png)


### PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have run linter locally
- [x] I have run unit and integration tests locally
  - [ ] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master

### Changes

- Added `headless` option 
- Added `headless` to `OfficialOptions`
