### PR TITLE
chore: support for Coinbase Wallet 3.6.0

### DIFF
--- a/.changeset/polite-dolls-rescue.md
+++ b/.changeset/polite-dolls-rescue.md
@@ -1,0 +1,6 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+- Support for Coinbase Wallet 3.6.0
+- Fixes static token symbol reference for Coinbase Wallet when using getTokenBalance

--- a/src/wallets/coinbase/actions.ts
+++ b/src/wallets/coinbase/actions.ts
@@ -145,7 +145,7 @@ export const getTokenBalance =
       await page.bringToFront();
       await page.getByTestId('portfolio-selector-nav-tabLabel--crypto').click();
       return await page.waitForSelector(
-        '//button[contains(@data-testid, "asset-item")][contains(@data-testid, "ETH")]',
+        `//button[contains(@data-testid, "asset-item")][contains(@data-testid, "${tokenSymbol}")]`,
         {
           timeout: 500,
         },
@@ -155,7 +155,7 @@ export const getTokenBalance =
     const readFromTestnetTab = async (): Promise<ElementHandle<SVGElement | HTMLElement>> => {
       await page.getByTestId('portfolio-selector-nav-tabLabel--testnet').click();
       return await page.waitForSelector(
-        '//button[contains(@data-testid, "asset-item")][contains(@data-testid, "ETH")]',
+        `//button[contains(@data-testid, "asset-item")][contains(@data-testid, "${tokenSymbol}")]`,
         {
           timeout: 500,
         },
@@ -176,15 +176,14 @@ export const getTokenBalance =
     if (!button) return 0;
 
     const text = await button.textContent();
-    const regexp = new RegExp(`(\\d.*) ${tokenSymbol}`, 'i');
-    const matches = text.match(regexp);
+    const currencyAmount = text.replaceAll(/ |,/g, '').split(tokenSymbol)[2];
 
-    return matches && matches.length >= 2 ? Number(matches[1]) : 0;
+    return currencyAmount ? Number(currencyAmount) : 0;
   };
 
 export const createAccount = (page: Page) => async (): Promise<void> => {
   await page.getByTestId('portfolio-header--switcher-cell-pressable').click();
-  await page.getByTestId('wallet-switcher--action').click();
+  await page.getByTestId('wallet-switcher--manage').click();
   await page.getByTestId('manage-wallets-account-item--action-cell-pressable').click();
 
   // Help prompt appears once

--- a/src/wallets/coinbase/coinbase.ts
+++ b/src/wallets/coinbase/coinbase.ts
@@ -25,7 +25,7 @@ import {
 
 export class CoinbaseWallet extends Wallet {
   static id = 'coinbase' as WalletIdOptions;
-  static recommendedVersion = '3.0.4';
+  static recommendedVersion = '3.6.0';
   static releasesUrl = 'https://api.github.com/repos/osis/coinbase-wallet-archive/releases';
   static homePath = '/index.html';
 

--- a/test/2-wallet.spec.ts
+++ b/test/2-wallet.spec.ts
@@ -3,7 +3,7 @@ import { Dappwright, OfficialOptions } from '../src';
 import { CoinbaseWallet } from '../src/wallets/coinbase/coinbase';
 import { clickOnLogo, openProfileDropdown } from '../src/wallets/metamask/actions/helpers';
 import { MetaMaskWallet } from '../src/wallets/metamask/metamask';
-import { forMetaMask } from './helpers/itForWallet';
+import { forCoinbase, forMetaMask } from './helpers/itForWallet';
 import launchBrowser from './helpers/launchBrowser';
 
 // TODO: Add this to the wallet interface
@@ -210,12 +210,18 @@ describe.each<OfficialOptions>([
     });
 
     it('should return token balance', async () => {
-      const tokenBalance: number = await wallet.getTokenBalance('ETH');
+      await forMetaMask(wallet, async () => {
+        const tokenBalance: number = await wallet.getTokenBalance('ETH');
 
-      // Unable to get local balance from Coinbase wallet. This is Goerli value for now.
-      const expectedTokenBalance = wallet instanceof MetaMaskWallet ? 999.9996 : 2.998;
+        expect(tokenBalance).toEqual(999.9996);
+      });
 
-      expect(tokenBalance).toEqual(expectedTokenBalance);
+      await forCoinbase(wallet, async () => {
+        const tokenBalance: number = await wallet.getTokenBalance('ETH');
+
+        // Unable to get local balance from Coinbase wallet. This is Goerli value for now.
+        expect(tokenBalance).toEqual(1000);
+      });
     });
 
     it('should return 0 token balance when token not found', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2015",
     "module": "commonjs",
     "moduleResolution": "node",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2021", "dom"],
     "typeRoots": ["./node_modules/@types", "./types"],
     "declaration": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Adds support for Coinbase Wallet 3.6.0. Also fixes static token symbol reference for Coinbase Wallet when using getTokenBalance

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master