### PR TITLE
fix: cache path mismatch in the downloader

### DIFF
--- a/.changeset/hungry-weeks-sell.md
+++ b/.changeset/hungry-weeks-sell.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+Fixes a cache path mismatch in the downloader

--- a/src/wallets/metamask/setup/downloader.ts
+++ b/src/wallets/metamask/setup/downloader.ts
@@ -66,16 +66,16 @@ export const downloadDir = (walletId: WalletIdOptions): string => {
 };
 
 const download = async (version: string, releasesUrl: string, location: string): Promise<string> => {
+  const extractDestination = path.resolve(location, version.replace(/\./g, '_'));
+
   if (version !== 'latest') {
-    const extractDestination = path.resolve(location, version.replace(/\./g, '_'));
     if (fs.existsSync(extractDestination) && !isEmpty(extractDestination)) return extractDestination;
   }
 
   // eslint-disable-next-line no-console
   console.log('Downloading extension...');
 
-  const { filename, downloadUrl, tag } = await getGithubRelease(releasesUrl, `v${version}`);
-  const extractDestination = path.resolve(location, tag.replace(/\./g, '_'));
+  const { filename, downloadUrl } = await getGithubRelease(releasesUrl, `v${version}`);
 
   // Clean if system tmp files are cleaned but dir structure can persist
   if (fs.existsSync(extractDestination) && isEmpty(extractDestination)) {


### PR DESCRIPTION
There was an issue where the extensions were downloading when they were already on every run downloaded, but not unzipped. This gets the package paths to be aligned.

### PR Checklist
- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master