### PR TITLE
chore: updates the releases repo for coinbase wallet

### DIFF
--- a/.changeset/clean-experts-count.md
+++ b/.changeset/clean-experts-count.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+updates the releases repo for coinbase wallet

--- a/src/wallets/coinbase/coinbase.ts
+++ b/src/wallets/coinbase/coinbase.ts
@@ -26,7 +26,7 @@ import {
 export class CoinbaseWallet extends Wallet {
   static id = 'coinbase' as WalletIdOptions;
   static recommendedVersion = '3.6.0';
-  static releasesUrl = 'https://api.github.com/repos/osis/coinbase-wallet-archive/releases';
+  static releasesUrl = 'https://api.github.com/repos/TenKeyLabs/coinbase-wallet-archive/releases';
   static homePath = '/index.html';
 
   options: WalletOptions;


### PR DESCRIPTION
The repo for Coinbase Wallet releases has moved to the Ten Key Labs org and this updates the url.

### PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master