### PR TITLE
chore: cleans up imports/exports

### DIFF
--- a/.changeset/wicked-squids-sin.md
+++ b/.changeset/wicked-squids-sin.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+chore: provides an explicit default export for the lib

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "microbundle --tsconfig tsconfig.build.json",
-    "dev": "microbundle --tsconfig tsconfig.build.json watch",
+    "build": "microbundle --tsconfig tsconfig.build.json --external os,https,zlib,stream",
+    "dev": "microbundle --tsconfig tsconfig.build.json --external os,https,zlib,stream watch",
     "lint": "eslint --color --ext .ts src/ test/",
     "lint:fix": "yarn run lint --fix",
     "test": "playwright test test/",

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -1,5 +1,5 @@
 import { Page } from 'playwright-core';
-import { getElementByContent, getInputByLabel } from '.';
+import { getElementByContent, getInputByLabel } from './selectors';
 
 export const waitForChromeState = async (page: Page): Promise<void> => {
   await page.waitForTimeout(3000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,15 @@
 // re-export
-export * from './bootstrap';
-export * from './launch';
+
+import { bootstrap } from './bootstrap';
+import { launch } from './launch';
+import { getWallet } from './wallets/wallets';
+
+const defaultObject = { bootstrap, launch, getWallet };
+export default defaultObject;
+
+export { bootstrap } from './bootstrap';
+export { launch } from './launch';
 export * from './types';
-export * from './wallets/metamask/setup';
+export { CoinbaseWallet } from './wallets/coinbase/coinbase';
+export { MetaMaskWallet } from './wallets/metamask/metamask';
 export { getWallet } from './wallets/wallets';

--- a/src/wallets/coinbase/actions.ts
+++ b/src/wallets/coinbase/actions.ts
@@ -1,6 +1,6 @@
 import { ElementHandle, Page } from 'playwright-core';
-import { AddNetwork, AddToken } from '../..';
 import { waitForChromeState } from '../../helpers';
+import { AddNetwork, AddToken } from '../../types';
 import { performPopupAction } from '../metamask/actions';
 import { WalletOptions } from '../wallets';
 

--- a/src/wallets/metamask/actions/addNetwork.ts
+++ b/src/wallets/metamask/actions/addNetwork.ts
@@ -1,7 +1,7 @@
 import { Page } from 'playwright-core';
 import { clickOnButton } from '../../../helpers';
+import { AddNetwork } from '../../../types';
 
-import { AddNetwork } from '../../../index';
 import { clickOnLogo, getErrorMessage, openNetworkDropdown } from './helpers';
 
 export const addNetwork =

--- a/src/wallets/metamask/actions/confirmTransaction.ts
+++ b/src/wallets/metamask/actions/confirmTransaction.ts
@@ -1,6 +1,6 @@
 import { Page } from 'playwright-core';
+import { TransactionOptions } from '../../../types';
 
-import { TransactionOptions } from '../../..';
 import { performPopupAction } from './util';
 
 export const confirmTransaction =

--- a/src/wallets/metamask/actions/helpers/actions.ts
+++ b/src/wallets/metamask/actions/helpers/actions.ts
@@ -1,5 +1,5 @@
 import { Page } from 'playwright-core';
-import { getAccountMenuButton, getSettingsSwitch } from '.';
+import { getAccountMenuButton, getSettingsSwitch } from './selectors';
 
 export const clickOnSettingsSwitch = async (page: Page, text: string): Promise<void> => {
   const button = await getSettingsSwitch(page, text);

--- a/test/2-wallet.spec.ts
+++ b/test/2-wallet.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-import { Dappwright } from '../src';
+import { Dappwright, MetaMaskWallet } from '../src';
 import { clickOnLogo, openProfileDropdown } from '../src/wallets/metamask/actions/helpers';
-import { MetaMaskWallet } from '../src/wallets/metamask/metamask';
 import { forCoinbase, forMetaMask } from './helpers/itForWallet';
 import { testWithWallet as test } from './helpers/testWithWallet';
 


### PR DESCRIPTION
This cleans up a few lingering warnings that have been around since the initial fork.

```
Circular dependency: src/wallets/metamask/actions/helpers/index.ts -> src/wallets/metamask/actions/helpers/actions.ts -> src/wallets/metamask/actions/helpers/index.ts
Entry module "src/index.ts" is using named and default exports together. Consumers of your bundle will have to use `dappwright["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning
Circular dependency: src/wallets/metamask/actions/helpers/index.ts -> src/wallets/metamask/actions/helpers/actions.ts -> src/wallets/metamask/actions/helpers/index.ts
Circular dependency: src/wallets/metamask/actions/helpers/index.ts -> src/wallets/metamask/actions/helpers/actions.ts -> src/wallets/metamask/actions/helpers/index.ts
Entry module "src/index.ts" is using named and default exports together. Consumers of your bundle will have to use `dappwright["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning
Creating a browser bundle that depends on Node.js built-in modules ("path", "os", "https", "zlib" and "stream"). You might need to include https://github.com/FredKSchott/rollup-plugin-polyfill-node
Circular dependency: src/wallets/metamask/actions/helpers/index.ts -> src/wallets/metamask/actions/helpers/actions.ts -> src/wallets/metamask/actions/helpers/index.ts
```

### PR Checklist
- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master

### Changes
- tests import from index.ts to ensure proper lib exports
- fixes circular imports
- provides a default export for index for better lib compatibility
- provides external dependencies to microbundle to silence warnings