### PR TITLE
chore: updates tests to use the official docker image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.30.0-focal
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -44,9 +46,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          npx playwright install --with-deps chromium
-          xvfb-run --auto-servernum yarn run test:ci
-
+          xvfb-run yarn run test:ci
       - name: Upload test results
         if: failure()
         uses: actions/upload-artifact@v3

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint --color --ext .ts src/ test/",
     "lint:fix": "yarn run lint --fix",
     "test": "playwright test test/",
-    "test:ci": "playwright test --headed --timeout 120000",
+    "test:ci": "playwright test --headed --timeout 200000",
     "test:debug": "playwright test --debug --timeout 0 test/",
     "test:dapp": "node --require ts-node/register test/dapp/start.ts",
     "changeset:publish": "yarn build && changeset publish"


### PR DESCRIPTION
Moves the tests to use the [official playwright docker images](https://mcr.microsoft.com/en-us/product/playwright/about).

Special thanks to @FranciszekMalcher for letting us know about these in #101. This initial implementation will use playwright 1.30 for compatibility purposes and will help with the next few bumps.

### PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master