### PR TITLE
chore: Improve error message when connecting to github to get extensi…

### DIFF
--- a/.changeset/ninety-ants-attack.md
+++ b/.changeset/ninety-ants-attack.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+Improved error message when connecting to github to get the extension's release

--- a/src/wallets/metamask/setup/downloader.ts
+++ b/src/wallets/metamask/setup/downloader.ts
@@ -152,7 +152,10 @@ const getGithubRelease = (releasesUrl: string, version: string): Promise<GithubR
 
       response.on('end', () => {
         const data = JSON.parse(body);
-        if (data.message) return reject(data.message);
+        if (data.message)
+          return reject(
+            `There was a problem connecting to github API to get the extension release (URL: ${releasesUrl}). Error: ${data.message}`,
+          );
         for (const result of data) {
           if (result.draft) continue;
           if (version === 'latest' || result.name.includes(version) || result.tag_name.includes(version)) {


### PR DESCRIPTION
Improved error message when connecting to github to get the extension's release.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally

### Changes

Improved error message when connecting to github to get the extension's release.

### Example

When the developer has an expired or invalid `process.env.GITHUB_TOKEN`:

Before:
`Bad credentials`

After: 
`There was a problem connecting to github API to get the extension release (URL: https://api.github.com/repos/metamask/metamask-extension/releases). Error: Bad credentials`

The previous version was very misleading becuase I was thinking that the problem was with my metamask `seed phrase` instead of with `github API token`. This change could help other future developers facing the same problem.
