### PR TITLE
chore: enables support for engines > 16

### DIFF
--- a/.changeset/rude-lobsters-wonder.md
+++ b/.changeset/rude-lobsters-wonder.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+chore: enables support for engines > 16

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dist/"
   ],
   "engines": {
-    "node": "16"
+    "node": ">=16"
   },
   "scripts": {
     "prebuild": "rimraf dist",


### PR DESCRIPTION
Node 16 is still supported but will be EOL September 2023. Folks are moving to 18 and this will allow a graceful transition.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master

Closes #105
