### PR TITLE
chore: bumps coinbase wallet to 3.14.2

### DIFF
--- a/src/wallets/coinbase/actions.ts
+++ b/src/wallets/coinbase/actions.ts
@@ -69,7 +69,7 @@ export const confirmTransaction = (page: Page) => async (): Promise<void> => {
   await performPopupAction(page, async (popup: Page): Promise<void> => {
     try {
       // Help prompt appears once
-      await (await popup.waitForSelector("text='Got it'", { timeout: 1000 })).click();
+      await (await popup.waitForSelector("text='Got it'", { timeout: 5000 })).click();
     } catch {
       // Ignore missing help prompt
     }

--- a/src/wallets/coinbase/coinbase.ts
+++ b/src/wallets/coinbase/coinbase.ts
@@ -25,7 +25,7 @@ import {
 
 export class CoinbaseWallet extends Wallet {
   static id = 'coinbase' as WalletIdOptions;
-  static recommendedVersion = '3.6.0';
+  static recommendedVersion = '3.14.2';
   static releasesUrl = 'https://api.github.com/repos/TenKeyLabs/coinbase-wallet-archive/releases';
   static homePath = '/index.html';
 


### PR DESCRIPTION
Bumps to latest version of Coinbase Wallet. Had to bump the wait time for the transaction help to accommodate a slower loading time for that modal.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master
