### PR TITLE
feat: run tests in parallel

### DIFF
--- a/.changeset/good-ducks-tan.md
+++ b/.changeset/good-ducks-tan.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": minor
+---
+
+Launch persistent contexts in parallel.

--- a/.changeset/good-ducks-tan.md
+++ b/.changeset/good-ducks-tan.md
@@ -1,5 +1,5 @@
 ---
-"@tenkeylabs/dappwright": minor
+'@tenkeylabs/dappwright': minor
 ---
 
-Launch persistent contexts in parallel.
+Add support for parallel testing.

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,11 +1,11 @@
 import { BrowserContext, Page } from 'playwright-core';
 import { launch } from './launch';
-import { Dappwright, OfficialOptions, ProcessOptions } from './types';
+import { Dappwright, OfficialOptions } from './types';
 import { getWallet, WalletOptions } from './wallets/wallets';
 
 export const bootstrap = async (
   browserName: string,
-  { seed, password, showTestNets, ...launchOptions }: OfficialOptions & WalletOptions & ProcessOptions,
+  { seed, password, showTestNets, ...launchOptions }: OfficialOptions & WalletOptions,
 ): Promise<[Dappwright, Page, BrowserContext]> => {
   const { browserContext } = await launch(browserName, launchOptions);
   const wallet = await getWallet(launchOptions.wallet, browserContext);

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,15 +1,12 @@
-import fs from 'fs';
-import * as path from 'path';
 import { BrowserContext, Page } from 'playwright-core';
-import { launch, sessionPath } from './launch';
-import { Dappwright, OfficialOptions } from './types';
+import { launch } from './launch';
+import { Dappwright, OfficialOptions, ProcessOptions } from './types';
 import { getWallet, WalletOptions } from './wallets/wallets';
 
 export const bootstrap = async (
   browserName: string,
-  { seed, password, showTestNets, ...launchOptions }: OfficialOptions & WalletOptions,
+  { seed, password, showTestNets, ...launchOptions }: OfficialOptions & WalletOptions & ProcessOptions,
 ): Promise<[Dappwright, Page, BrowserContext]> => {
-  fs.rmSync(path.join(sessionPath, launchOptions.wallet), { recursive: true, force: true });
   const { browserContext } = await launch(browserName, launchOptions);
   const wallet = await getWallet(launchOptions.wallet, browserContext);
   await wallet.setup({ seed, password, showTestNets });

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -22,8 +22,8 @@ export async function launch(browserName: string, options: OfficialOptions): Pro
 
   if (options.headless != false) browserArgs.push(`--headless=new`);
 
-  const parallelIndex = process.env.TEST_PARALLEL_INDEX || '0';
-  const userDataDir = path.join(sessionPath, options.wallet, parallelIndex);
+  const workerIndex = process.env.TEST_WORKER_INDEX || '0';
+  const userDataDir = path.join(sessionPath, options.wallet, workerIndex);
 
   fs.rmSync(userDataDir, { recursive: true, force: true });
 

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import * as path from 'path';
 import playwright from 'playwright-core';
 
-import { DappwrightLaunchResponse, OfficialOptions, ProcessOptions } from './types';
+import { DappwrightLaunchResponse, OfficialOptions } from './types';
 import { getWallet, getWalletType } from './wallets/wallets';
 
 /**
@@ -11,10 +11,7 @@ import { getWallet, getWalletType } from './wallets/wallets';
  * */
 export const sessionPath = path.resolve(os.tmpdir(), 'dappwright', 'session');
 
-export async function launch(
-  browserName: string,
-  options: OfficialOptions & ProcessOptions,
-): Promise<DappwrightLaunchResponse> {
+export async function launch(browserName: string, options: OfficialOptions): Promise<DappwrightLaunchResponse> {
   const { ...officialOptions } = options;
   const wallet = getWalletType(officialOptions.wallet);
   if (!wallet) throw new Error('Wallet not supported');
@@ -25,7 +22,8 @@ export async function launch(
 
   if (options.headless != false) browserArgs.push(`--headless=new`);
 
-  const userDataDir = path.join(sessionPath, options.wallet, (options.workerId || 0).toString());
+  const workerId = process.env.TEST_PARALLEL_INDEX || '0';
+  const userDataDir = path.join(sessionPath, options.wallet, workerId);
   fs.rmSync(userDataDir, { recursive: true, force: true });
   const browserContext = await playwright.chromium.launchPersistentContext(userDataDir, {
     headless: false,

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -22,9 +22,11 @@ export async function launch(browserName: string, options: OfficialOptions): Pro
 
   if (options.headless != false) browserArgs.push(`--headless=new`);
 
-  const workerId = process.env.TEST_PARALLEL_INDEX || '0';
-  const userDataDir = path.join(sessionPath, options.wallet, workerId);
+  const parallelIndex = process.env.TEST_PARALLEL_INDEX || '0';
+  const userDataDir = path.join(sessionPath, options.wallet, parallelIndex);
+
   fs.rmSync(userDataDir, { recursive: true, force: true });
+
   const browserContext = await playwright.chromium.launchPersistentContext(userDataDir, {
     headless: false,
     args: browserArgs,

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,10 @@ export type OfficialOptions = DappwrightBrowserLaunchArgumentOptions & {
   headless?: boolean;
 };
 
+export type ProcessOptions = {
+  workerId?: number;
+};
+
 export type DappwrightLaunchResponse = {
   wallet: Wallet;
   browserContext: BrowserContext;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,10 +19,6 @@ export type OfficialOptions = DappwrightBrowserLaunchArgumentOptions & {
   headless?: boolean;
 };
 
-export type ProcessOptions = {
-  workerId?: number;
-};
-
 export type DappwrightLaunchResponse = {
   wallet: Wallet;
   browserContext: BrowserContext;


### PR DESCRIPTION
**Add support for parallel testing.**

This pull request adds support for parallel testing by creating a separate Playwright user data directory for each worker. This prevents the workers from interfering with each other and allows them to run independently.

It reads the worker index from `process.env.TEST_WORKER_INDEX` like stated [here](https://playwright.dev/docs/test-parallel#worker-index-and-parallel-index).

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally
  - [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master