### PR TITLE
fix: exact text matches for switching networks

### DIFF
--- a/.changeset/tidy-pets-argue.md
+++ b/.changeset/tidy-pets-argue.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+fix: exact text matches for switching networks

--- a/src/wallets/metamask/actions/switchNetwork.ts
+++ b/src/wallets/metamask/actions/switchNetwork.ts
@@ -8,7 +8,7 @@ export const switchNetwork =
     await page.bringToFront();
     await openNetworkDropdown(page);
 
-    await page.locator('.multichain-network-list-menu').getByRole('button', { name: network }).click();
+    await page.locator('.multichain-network-list-menu').getByRole('button', { name: network, exact: true }).click();
 
     await waitForChromeState(page);
   };

--- a/test/2-wallet.spec.ts
+++ b/test/2-wallet.spec.ts
@@ -92,10 +92,10 @@ test.describe('when interacting with the wallet', () => {
     test.describe('switchNetwork', () => {
       test('should switch network, localhost', async ({ wallet }) => {
         if (wallet instanceof MetaMaskWallet) {
-          await wallet.switchNetwork('localhost');
+          await wallet.switchNetwork('Goerli');
 
           const selectedNetwork = await wallet.page.locator('.mm-picker-network > p').textContent();
-          expect(selectedNetwork).toEqual('Localhost 8545');
+          expect(selectedNetwork).toEqual('Goerli');
         } else {
           console.warn('Coinbase skips network switching');
         }
@@ -177,7 +177,7 @@ test.describe('when interacting with the wallet', () => {
 
   test.describe('getTokenBalance', () => {
     test.beforeEach(async ({ wallet }) => {
-      if (wallet instanceof MetaMaskWallet) await wallet.switchNetwork('localhost');
+      if (wallet instanceof MetaMaskWallet) await wallet.switchNetwork('Localhost 8545');
     });
 
     test('should return token balance', async ({ wallet }) => {


### PR DESCRIPTION
**Short description of work done**
Fixes #240 

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master

### Changes
This will require exact text matches for switching networks.