### PR TITLE
fix: scope of switch account selector to the menu dialog

### DIFF
--- a/.changeset/witty-bees-cheat.md
+++ b/.changeset/witty-bees-cheat.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+fix: scope of switch account selector to the menu dialog

--- a/src/wallets/metamask/actions/switchAccount.ts
+++ b/src/wallets/metamask/actions/switchAccount.ts
@@ -1,5 +1,4 @@
 import { Page } from 'playwright-core';
-import { clickOnElement } from '../../../helpers';
 import { openAccountMenu } from './helpers';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -9,6 +8,8 @@ export const switchAccount =
     await page.bringToFront();
     await openAccountMenu(page);
 
-    // TODO: use different approach? maybe change param to account name
-    await clickOnElement(page, `Account ${accountNumber}`);
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: `Account ${accountNumber}`, exact: true })
+      .click();
   };


### PR DESCRIPTION
**Short description of work done**
Fixes #233

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master

### Changes
Tighter scope on the selector so that playwright doesn't get confused by the other account button on the main page.