### PR TITLE
fix: metamask not settling on the homescreen after settings adjustments

### DIFF
--- a/.changeset/dry-lizards-battle.md
+++ b/.changeset/dry-lizards-battle.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+fix: metamask not settling on the homescreen after settings adjustments

--- a/src/wallets/metamask/setup/setupActions.ts
+++ b/src/wallets/metamask/setup/setupActions.ts
@@ -2,7 +2,7 @@ import { Page } from 'playwright-core';
 
 import { clickOnButton, typeOnInputField, waitForChromeState } from '../../../helpers';
 import { WalletOptions } from '../../wallets';
-import { clickOnSettingsSwitch, openAccountOptionsMenu } from '../actions/helpers';
+import { clickOnLogo, clickOnSettingsSwitch, openAccountOptionsMenu } from '../actions/helpers';
 
 export async function goToSettings(metamaskPage: Page): Promise<void> {
   await openAccountOptionsMenu(metamaskPage);
@@ -14,6 +14,8 @@ export async function adjustSettings(metamaskPage: Page): Promise<void> {
   await metamaskPage.locator('.tab-bar__tab', { hasText: 'Advanced' }).click();
 
   await clickOnSettingsSwitch(metamaskPage, 'Show test networks');
+  await clickOnLogo(metamaskPage);
+
   await waitForChromeState(metamaskPage);
 }
 

--- a/test/helpers/walletTest.ts
+++ b/test/helpers/walletTest.ts
@@ -18,6 +18,9 @@ export const testWithWallet = test.extend<{
 
       // Swap network chain IDs to match 31337
       if (wallet instanceof MetaMaskWallet) {
+        const onHomeScreen = await wallet.page.getByTestId('eth-overview__primary-currency').isVisible();
+        if (!onHomeScreen) throw 'Wallet Setup Error: Did not settle on home screen.';
+
         await wallet.addNetwork({
           networkName: 'Localhost 8545',
           rpc: 'http://localhost:8545',


### PR DESCRIPTION
**Short description of work done**
Fixes #246. Adjusts tests to protect from this bad scenario in the future.

### PR Checklist
- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master