### PR TITLE
feat: adds support for signin operations

### DIFF
--- a/.changeset/unlucky-bottles-melt.md
+++ b/.changeset/unlucky-bottles-melt.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+feat: adds support for signin actions

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export type Dappwright = {
   importPK: (pk: string) => Promise<void>;
   lock: () => Promise<void>;
   sign: () => Promise<void>;
+  signin: () => Promise<void>;
   switchAccount: (accountNumber: number) => Promise<void>;
   switchNetwork: (network: string) => Promise<void>;
   unlock: (password?: string) => Promise<void>;

--- a/src/wallets/coinbase/actions.ts
+++ b/src/wallets/coinbase/actions.ts
@@ -47,6 +47,11 @@ export const sign = (page: Page) => async (): Promise<void> => {
   });
 };
 
+export const signin = async (): Promise<void> => {
+  // eslint-disable-next-line no-console
+  console.warn('signin not implemented');
+};
+
 export const lock = (page: Page) => async (): Promise<void> => {
   await page.getByTestId('settings-navigation-link').click();
   await page.getByTestId('lock-wallet-button').click();

--- a/src/wallets/coinbase/coinbase.ts
+++ b/src/wallets/coinbase/coinbase.ts
@@ -19,6 +19,7 @@ import {
   lock,
   navigateHome,
   sign,
+  signin,
   switchAccount,
   switchNetwork,
   unlock,
@@ -54,6 +55,7 @@ export class CoinbaseWallet extends Wallet {
   importPK = importPK;
   lock = lock(this.page);
   sign = sign(this.page);
+  signin = signin;
   switchAccount = switchAccount(this.page);
   switchNetwork = switchNetwork;
   unlock = unlock(this.page);

--- a/src/wallets/metamask/actions/approve.ts
+++ b/src/wallets/metamask/actions/approve.ts
@@ -5,19 +5,20 @@ import { performPopupAction } from './util';
 
 export const approve = (page: Page) => async (): Promise<void> => {
   await performPopupAction(page, async (popup) => {
-    // Wait for popup to load
-    await popup.waitForLoadState();
-    await popup.bringToFront();
-
-    // Select first account
-    await popup.locator('input[type="checkbox"]').first().check();
-
-    // Go through the prompts
-    await clickOnButton(popup, 'Next');
-    await clickOnButton(popup, 'Connect');
-
-    // Wait and close
+    await connect(popup);
     await waitForChromeState(page);
-    await popup.close();
   });
+};
+
+export const connect = async (popup: Page): Promise<void> => {
+  // Wait for popup to load
+  await popup.waitForLoadState();
+  await popup.bringToFront();
+
+  // Select first account
+  await popup.locator('input[type="checkbox"]').first().check();
+
+  // Go through the prompts
+  await clickOnButton(popup, 'Next');
+  await clickOnButton(popup, 'Connect');
 };

--- a/src/wallets/metamask/actions/index.ts
+++ b/src/wallets/metamask/actions/index.ts
@@ -9,6 +9,7 @@ export * from './getTokenBalance';
 export * from './importPk';
 export * from './lock';
 export * from './sign';
+export * from './signin';
 export * from './switchAccount';
 export * from './switchNetwork';
 export * from './unlock';

--- a/src/wallets/metamask/actions/signin.ts
+++ b/src/wallets/metamask/actions/signin.ts
@@ -1,0 +1,19 @@
+import { Page } from 'playwright-core';
+
+import { clickOnButton, waitForChromeState } from '../../../helpers';
+import { connect } from './approve';
+import { performPopupAction } from './util';
+
+export const signin = (page: Page) => async (): Promise<void> => {
+  await performPopupAction(page, async (popup) => {
+    await popup.waitForSelector('#app-content .app');
+
+    const signatureTextVisible = await popup.getByText('Signature request').isVisible();
+    if (!signatureTextVisible) {
+      await connect(popup);
+    }
+
+    await clickOnButton(popup, 'Sign');
+    await waitForChromeState(page);
+  });
+};

--- a/src/wallets/metamask/metamask.ts
+++ b/src/wallets/metamask/metamask.ts
@@ -12,6 +12,7 @@ import {
   importPk,
   lock,
   sign,
+  signin,
   switchAccount,
   switchNetwork,
   unlock,
@@ -59,6 +60,7 @@ export class MetaMaskWallet extends Wallet {
   importPK = importPk(this.page);
   lock = lock(this.page);
   sign = sign(this.page);
+  signin = signin(this.page);
   switchAccount = switchAccount(this.page);
   switchNetwork = switchNetwork(this.page);
   unlock = unlock(this.page);

--- a/src/wallets/wallet.ts
+++ b/src/wallets/wallet.ts
@@ -38,6 +38,7 @@ export default abstract class Wallet implements Dappwright {
   abstract importPK: (pk: string) => Promise<void>;
   abstract lock: () => Promise<void>;
   abstract sign: () => Promise<void>;
+  abstract signin: () => Promise<void>;
   abstract switchAccount: (accountNumber: number) => Promise<void>;
   abstract switchNetwork: (network: string) => Promise<void>;
   abstract unlock: (password?: string) => Promise<void>;

--- a/test/3-dapp.spec.ts
+++ b/test/3-dapp.spec.ts
@@ -1,5 +1,5 @@
 import { CoinbaseWallet } from '../src';
-import { forCoinbase } from './helpers/itForWallet';
+import { forCoinbase, forMetaMask } from './helpers/itForWallet';
 import { testWithWallet as test } from './helpers/walletTest';
 
 test.describe('when interacting with dapps', () => {
@@ -9,18 +9,46 @@ test.describe('when interacting with dapps', () => {
   });
 
   test('should be able to connect', async ({ wallet, page }) => {
-    await page.click('.connect-button');
-    await wallet.approve();
+    await forCoinbase(wallet, async () => {
+      await page.click('.connect-button');
+      await wallet.approve();
 
-    await page.waitForSelector('#connected');
+      await page.waitForSelector('#connected');
+    });
+  });
+
+  test('should be able to sign in', async ({ wallet, page }) => {
+    await forMetaMask(wallet, async () => {
+      await page.click('.signin-button');
+      await wallet.signin();
+
+      await page.waitForSelector('#signedIn');
+    });
+  });
+
+  test('should be able to sign in again', async ({ wallet, page }) => {
+    await forMetaMask(wallet, async () => {
+      await page.click('.signin-button');
+      await wallet.signin();
+
+      await page.waitForSelector('#signedIn');
+    });
   });
 
   test('should be able to switch networks', async ({ wallet, page }) => {
-    await forCoinbase(wallet, async () => {
-      await page.click('.switch-network-button');
+    await page.click('.switch-network-button');
 
-      await page.waitForSelector('#switchNetwork');
+    await forMetaMask(wallet, async () => {
+      await wallet.switchNetwork('Goerli');
+      await page.bringToFront();
+      await page.reload();
+      await wallet.page.reload();
+
+      await page.click('.switch-network-button');
+      await wallet.confirmNetworkSwitch();
     });
+
+    await page.waitForSelector('#switchNetwork');
   });
 
   test('should be able to sign messages', async ({ wallet, page }) => {

--- a/test/dapp/public/index.html
+++ b/test/dapp/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -14,6 +14,7 @@
   </head>
   <body>
     <button class="connect-button">Connect</button>
+    <button class="signin-button">Sign In</button>
     <button class="switch-network-button">Switch Network</button>
     <button class="sign-button">Sign</button>
     <button class="increase-button">Increase</button>

--- a/test/dapp/public/main.js
+++ b/test/dapp/public/main.js
@@ -22,6 +22,34 @@ async function start() {
     document.body.appendChild(connected);
   });
 
+  const siweSign = async function (siweMessage) {
+    try {
+      accounts = await ethereum.request({
+        method: 'eth_requestAccounts',
+      });
+      const from = accounts[0];
+      const msg = `0x${btoa(siweMessage, 'utf8').toString('hex')}`;
+      await ethereum.request({
+        method: 'personal_sign',
+        params: [msg, from],
+      });
+      const signedIn = document.createElement('div');
+      signedIn.id = 'signedIn';
+      signedIn.textContent = 'signed in';
+      document.body.appendChild(signedIn);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const signinButton = document.querySelector('.signin-button');
+  signinButton.addEventListener('click', async function () {
+    const domain = window.location.host;
+    const from = accounts[0];
+    const siweMessage = `${domain} wants you to sign in with your Ethereum account:\n${from}\n\nI accept the MetaMask Terms of Service: https://community.metamask.io/tos\n\nURI: https://${domain}\nVersion: 1\nChain ID: 1\nNonce: 32891757\nIssued At: 2021-09-30T16:25:24.000Z`;
+    siweSign(siweMessage);
+  });
+
   const switchNetworkButton = document.querySelector('.switch-network-button');
   switchNetworkButton.addEventListener('click', async function () {
     await ethereum.request({


### PR DESCRIPTION
**Short description of work done**
- Abstracts connect action to be used for a connect or signin since the former is a subset of the latter.
- Implements Sign In action for Metamask
- Adds tests for both the initial signin flow, and a re-signin

### PR Checklist
- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master

### Issues
Closes #271 
