### PR TITLE
chore: bump metamask

### DIFF
--- a/.changeset/spotty-ravens-joke.md
+++ b/.changeset/spotty-ravens-joke.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+Bumps MetaMask to 11.16.3

--- a/src/wallets/metamask/actions/approve.ts
+++ b/src/wallets/metamask/actions/approve.ts
@@ -20,5 +20,5 @@ export const connect = async (popup: Page): Promise<void> => {
 
   // Go through the prompts
   await clickOnButton(popup, 'Next');
-  await clickOnButton(popup, 'Connect');
+  await clickOnButton(popup, 'Confirm');
 };

--- a/src/wallets/metamask/metamask.ts
+++ b/src/wallets/metamask/metamask.ts
@@ -27,7 +27,7 @@ import { adjustSettings, clearOnboardingHelp, closePopup, createPassword, import
 
 export class MetaMaskWallet extends Wallet {
   static id = 'metamask' as WalletIdOptions;
-  static recommendedVersion = '11.10.0';
+  static recommendedVersion = '11.16.3';
   static releasesUrl = 'https://api.github.com/repos/metamask/metamask-extension/releases';
   static homePath = '/home.html';
 

--- a/src/wallets/metamask/setup/setupActions.ts
+++ b/src/wallets/metamask/setup/setupActions.ts
@@ -10,6 +10,7 @@ export async function goToSettings(metamaskPage: Page): Promise<void> {
 }
 
 export async function adjustSettings(metamaskPage: Page): Promise<void> {
+  await clickOnButton(metamaskPage, 'Manage in settings');
   await goToSettings(metamaskPage);
   await metamaskPage.locator('.tab-bar__tab', { hasText: 'Advanced' }).click();
 

--- a/test/2-wallet.spec.ts
+++ b/test/2-wallet.spec.ts
@@ -92,9 +92,9 @@ test.describe('when interacting with the wallet', () => {
     test.describe('switchNetwork', () => {
       test('should switch network, localhost', async ({ wallet }) => {
         if (wallet instanceof MetaMaskWallet) {
-          await wallet.switchNetwork('Goerli');
+          await wallet.switchNetwork('Sepolia');
 
-          const selectedNetwork = wallet.page.getByTestId('network-display').getByText('Goerli');
+          const selectedNetwork = wallet.page.getByTestId('network-display').getByText('Sepolia');
           expect(selectedNetwork).toBeVisible();
         } else {
           console.warn('Coinbase skips network switching');
@@ -187,7 +187,7 @@ test.describe('when interacting with the wallet', () => {
         expect(tokenBalance).toEqual(999.9996);
       });
 
-      // Unable to get local balance from Coinbase wallet. This is Goerli value for now.
+      // Unable to get local balance from Coinbase wallet. This is Sepolia value for now.
       await forCoinbase(wallet, async () => {
         expect(tokenBalance).toEqual(999.999);
       });

--- a/test/3-dapp.spec.ts
+++ b/test/3-dapp.spec.ts
@@ -46,7 +46,7 @@ test.describe('when interacting with dapps', () => {
     await page.click('.switch-network-button');
 
     await forMetaMask(wallet, async () => {
-      await wallet.switchNetwork('Goerli');
+      await wallet.switchNetwork('Sepolia');
       await page.bringToFront();
       await page.reload();
       await wallet.page.reload();


### PR DESCRIPTION
**Short description of work done**
- Bumps Metamask to 11.16.3
- Adjusts for UX changes
- Switches tests from Goerli to Sepolia

### PR Checklist
- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master

### Issues
Closes #337
Curious if this helps with #321
