### PR TITLE
chore: bumps metamask to 11.16.13

### DIFF
--- a/.changeset/lazy-singers-hope.md
+++ b/.changeset/lazy-singers-hope.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+bumps metamask to 11.16.13

--- a/src/wallets/metamask/metamask.ts
+++ b/src/wallets/metamask/metamask.ts
@@ -27,7 +27,7 @@ import { adjustSettings, clearOnboardingHelp, closePopup, createPassword, import
 
 export class MetaMaskWallet extends Wallet {
   static id = 'metamask' as WalletIdOptions;
-  static recommendedVersion = '11.16.3';
+  static recommendedVersion = '11.16.13';
   static releasesUrl = 'https://api.github.com/repos/metamask/metamask-extension/releases';
   static homePath = '/home.html';
 


### PR DESCRIPTION
**Short description of work done**
bumps MetaMask to 11.16.3 as a possible fix for #344 

### PR Checklist
- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master