### PR TITLE
fix: siwe complient signature

### DIFF
--- a/src/wallets/metamask/actions/signin.ts
+++ b/src/wallets/metamask/actions/signin.ts
@@ -1,6 +1,6 @@
 import { Page } from 'playwright-core';
 
-import { clickOnButton, waitForChromeState } from '../../../helpers';
+import { waitForChromeState } from '../../../helpers';
 import { connect } from './approve';
 import { performPopupAction } from './util';
 
@@ -8,12 +8,19 @@ export const signin = (page: Page) => async (): Promise<void> => {
   await performPopupAction(page, async (popup) => {
     await popup.waitForSelector('#app-content .app');
 
-    const signatureTextVisible = await popup.getByText('Signature request').isVisible();
-    if (!signatureTextVisible) {
+    const [signatureTextVisible, signinTextVisible] = await Promise.all([
+      popup.getByText('Signature request').isVisible(),
+      popup.getByText('Sign-in request').isVisible(),
+    ]);
+
+    if (!signatureTextVisible && !signinTextVisible) {
       await connect(popup);
     }
 
-    await clickOnButton(popup, 'Sign');
+    const signInButton = popup.getByTestId('page-container-footer-next');
+    await signInButton.scrollIntoViewIfNeeded();
+    await signInButton.click();
+
     await waitForChromeState(page);
   });
 };

--- a/test/3-dapp.spec.ts
+++ b/test/3-dapp.spec.ts
@@ -33,6 +33,15 @@ test.describe('when interacting with dapps', () => {
     });
   });
 
+  test.only('should sign SIWE complient message', async ({ wallet, page }) => {
+    await forMetaMask(wallet, async () => {
+      await page.click('.sign-siwe-message');
+      await wallet.signin();
+
+      await page.waitForSelector('#siwe-signed');
+    });
+  });
+
   test('should be able to sign in again', async ({ wallet, page }) => {
     await forMetaMask(wallet, async () => {
       await page.click('.signin-button');

--- a/test/3-dapp.spec.ts
+++ b/test/3-dapp.spec.ts
@@ -33,12 +33,12 @@ test.describe('when interacting with dapps', () => {
     });
   });
 
-  test.only('should sign SIWE complient message', async ({ wallet, page }) => {
+  test('should sign SIWE complient message', async ({ wallet, page }) => {
     await forMetaMask(wallet, async () => {
       await page.click('.sign-siwe-message');
       await wallet.signin();
 
-      await page.waitForSelector('#siwe-signed');
+      await page.waitForSelector('#siweSigned');
     });
   });
 

--- a/test/dapp/public/index.html
+++ b/test/dapp/public/index.html
@@ -14,6 +14,7 @@
   </head>
   <body>
     <button class="connect-button">Connect</button>
+    <button class="sign-siwe-message">Sign SIWE message</button>
     <button class="signin-button">Sign In</button>
     <button class="switch-network-button">Switch Network</button>
     <button class="sign-button">Sign</button>

--- a/test/dapp/public/main.js
+++ b/test/dapp/public/main.js
@@ -31,13 +31,13 @@ async function start() {
     document.body.appendChild(connected);
   });
 
-  const siweSign = async function (siweMessage) {
+  const personalSign = async function (message) {
     try {
       accounts = await ethereum.request({
         method: 'eth_requestAccounts',
       });
       const from = accounts[0];
-      const msg = `0x${btoa(siweMessage, 'utf8').toString('hex')}`;
+      const msg = `0x${btoa(message, 'utf8').toString('hex')}`;
       await ethereum.request({
         method: 'personal_sign',
         params: [msg, from],
@@ -55,8 +55,8 @@ async function start() {
   signinButton.addEventListener('click', async function () {
     const domain = window.location.host;
     const from = accounts[0];
-    const siweMessage = `${domain} wants you to sign in with your Ethereum account:\n${from}\n\nI accept the MetaMask Terms of Service: https://community.metamask.io/tos\n\nURI: https://${domain}\nVersion: 1\nChain ID: 1\nNonce: 32891757\nIssued At: 2021-09-30T16:25:24.000Z`;
-    siweSign(siweMessage);
+    const message = `${domain} wants you to sign in with your Ethereum account:\n${from}\n\nI accept the MetaMask Terms of Service: https://community.metamask.io/tos\n\nURI: https://${domain}\nVersion: 1\nChain ID: 1\nNonce: 32891757\nIssued At: 2021-09-30T16:25:24.000Z`;
+    personalSign(message);
   });
 
   const switchNetworkButton = document.querySelector('.switch-network-button');

--- a/test/dapp/public/main.js
+++ b/test/dapp/public/main.js
@@ -31,7 +31,7 @@ async function start() {
     document.body.appendChild(connected);
   });
 
-  const personalSign = async function (message) {
+  const personalSign = async function (message, signedMessageId = 'signedIn', signedMessage = 'signed in') {
     try {
       accounts = await ethereum.request({
         method: 'eth_requestAccounts',
@@ -42,8 +42,8 @@ async function start() {
         params: [message, from],
       });
       const signedIn = document.createElement('div');
-      signedIn.id = 'signedIn';
-      signedIn.textContent = 'signed in';
+      signedIn.id = signedMessageId;
+      signedIn.textContent = signedMessage;
       document.body.appendChild(signedIn);
     } catch (err) {
       console.error(err);
@@ -78,7 +78,7 @@ async function start() {
     const message = await getSiweMessage({
       origin: window.location.host,
       uri: window.location.href,
-      address: accounts[0],
+      account: accounts[0],
       version: 1,
       chainId: 1,
       nonce: 1,
@@ -86,7 +86,7 @@ async function start() {
       expirationTime: new Date().toISOString(),
     });
 
-    personalSign(message);
+    personalSign(message, 'siweSigned', 'signed SIWE message');
   });
 
   const switchNetworkButton = document.querySelector('.switch-network-button');

--- a/test/dapp/public/main.js
+++ b/test/dapp/public/main.js
@@ -65,6 +65,31 @@ async function start() {
     personalSign(message);
   });
 
+  const signSiweMessage = document.querySelector('.sign-siwe-message');
+  signSiweMessage.addEventListener('click', async function () {
+    const domain = window.location.host;
+    const address = accounts[0];
+    const statement = 'I accept the Terms of Service: https://test.com/tos';
+    const uri = `https://${domain}`;
+    const version = 1;
+    const chainId = 1;
+    const nonce = 1;
+    const issuedAt = new Date();
+
+    const message = await getSiweMessage({
+      origin: domain,
+      address,
+      statement,
+      uri,
+      version,
+      chainId,
+      nonce,
+      issuedAt,
+    });
+
+    personalSign(message);
+  });
+
   const switchNetworkButton = document.querySelector('.switch-network-button');
   switchNetworkButton.addEventListener('click', async function () {
     await ethereum.request({

--- a/test/dapp/public/main.js
+++ b/test/dapp/public/main.js
@@ -37,10 +37,9 @@ async function start() {
         method: 'eth_requestAccounts',
       });
       const from = accounts[0];
-      const msg = `0x${btoa(message, 'utf8').toString('hex')}`;
       await ethereum.request({
         method: 'personal_sign',
-        params: [msg, from],
+        params: [message, from],
       });
       const signedIn = document.createElement('div');
       signedIn.id = 'signedIn';

--- a/test/dapp/public/main.js
+++ b/test/dapp/public/main.js
@@ -51,6 +51,12 @@ async function start() {
     }
   };
 
+  const getSiweMessage = async function ({ origin, address, statement, uri, version, chainId, nonce, issuedAt }) {
+    const prefix = `${origin} wants you to sign in with your Ethereum account:\n${address}\n\n${statement}`;
+    const suffix = `URI: ${uri}\nVersion: ${version}\nChain ID: ${chainId}\nNonce: ${nonce}\nIssued At: ${issuedAt.toISOString()}`;
+    return `${prefix}\n${suffix}`;
+  };
+
   const signinButton = document.querySelector('.signin-button');
   signinButton.addEventListener('click', async function () {
     const domain = window.location.host;

--- a/test/dapp/public/main.js
+++ b/test/dapp/public/main.js
@@ -50,10 +50,19 @@ async function start() {
     }
   };
 
-  const getSiweMessage = async function ({ origin, address, statement, uri, version, chainId, nonce, issuedAt }) {
-    const prefix = `${origin} wants you to sign in with your Ethereum account:\n${address}\n\n${statement}`;
-    const suffix = `URI: ${uri}\nVersion: ${version}\nChain ID: ${chainId}\nNonce: ${nonce}\nIssued At: ${issuedAt.toISOString()}`;
-    return `${prefix}\n${suffix}`;
+  const getSiweMessage = async function ({ origin, account, uri, version, chainId, issuedAt, expirationTime }) {
+    return (
+      `${origin} wants you to sign in with your Ethereum account:\n` +
+      `${account}\n` +
+      '\n' +
+      '\n' +
+      `URI: ${uri}\n` +
+      `Version: ${version}\n` +
+      `Chain ID: ${chainId}\n` +
+      'Nonce: 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\n' +
+      `Issued At: ${issuedAt}\n` +
+      `Expiration Time: ${expirationTime}`
+    );
   };
 
   const signinButton = document.querySelector('.signin-button');
@@ -66,24 +75,15 @@ async function start() {
 
   const signSiweMessage = document.querySelector('.sign-siwe-message');
   signSiweMessage.addEventListener('click', async function () {
-    const domain = window.location.host;
-    const address = accounts[0];
-    const statement = 'I accept the Terms of Service: https://test.com/tos';
-    const uri = `https://${domain}`;
-    const version = 1;
-    const chainId = 1;
-    const nonce = 1;
-    const issuedAt = new Date();
-
     const message = await getSiweMessage({
-      origin: domain,
-      address,
-      statement,
-      uri,
-      version,
-      chainId,
-      nonce,
-      issuedAt,
+      origin: window.location.host,
+      uri: window.location.href,
+      address: accounts[0],
+      version: 1,
+      chainId: 1,
+      nonce: 1,
+      issuedAt: new Date().toISOString(),
+      expirationTime: new Date().toISOString(),
     });
 
     personalSign(message);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide all required information
-->

**Short description of work done**
<!-- e.g. Refactored auth logic as part of the transition to OAuth -->
This PR fixes the signIn action for MetaMask to support SIWE-compliant messages.

MetaMask displays a different UI with alternate text when handling SIWE-compliant messages, which caused issues in the current implementation. The original code relied on detecting the “Signature request” header and interacting with a button labeled “Sign.” However, this approach failed when the UI varied for SIWE requests.

The core change is in the signIn method, where a check for “Sign-in request” was added. Instead of relying on the button text to identify the clickable element, the update now uses the testId directive. This directive is common to both button types, handling SIWE-compliant messages as well as regular signature requests.

### PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have run linter locally
- [x] I have run unit and integration tests locally
- [x] Rebased to master branch / merged master

### Changes
<!-- Please describe all changes made to codebase. -->
- `signIn` method
    - Include check for "Sign-in request"
    - Click the button with testId `page-container-footer-next` instead of relaying on the button text
  
 - Tests
    - add test for SIWE-compliant messages  
  
- Test dapp
    - rename method `siweSign` to `personalSign`, since the siweSign wasn't SIWE-compliant
    - add additional paramaters `signedMessageId` and `signedMessage` to `personalSign` in order to reuse the function to request the signature of SIWE messages
    - add `signSiweMessage` function that requests the signature of a SIWE-compliant message
    - create method `getSiweMessage` that returns a SIWE-compliant message
 
### Example
<!-- You can add screenshots or videos to show changed behaviour -->
https://github.com/user-attachments/assets/2e8a25fa-41c7-4368-81af-777364e5fd02


### Issues
<!-- Use github keyword to close issues that are related to this PR -->

<!-- [REQUIRED] -->
Closes #366 
