### PR TITLE
chore(coinbase): bump to 3.109.0

### DIFF
--- a/.changeset/loud-bushes-return.md
+++ b/.changeset/loud-bushes-return.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+chore(coinbase): bump to 3.109.0

--- a/src/wallets/coinbase/coinbase.ts
+++ b/src/wallets/coinbase/coinbase.ts
@@ -28,7 +28,7 @@ import {
 
 export class CoinbaseWallet extends Wallet {
   static id = 'coinbase' as WalletIdOptions;
-  static recommendedVersion = '3.96.0';
+  static recommendedVersion = '3.109.0';
   static releasesUrl = 'https://api.github.com/repos/TenKeyLabs/coinbase-wallet-archive/releases';
   static homePath = '/index.html';
 


### PR DESCRIPTION
**Short description of work done**

bumps coinbase to 3.109.0

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally