### PR TITLE
fix(metamask): scroll account menu button into view before clicking

### DIFF
--- a/.changeset/smooth-baths-ring.md
+++ b/.changeset/smooth-baths-ring.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+fix(metamask): scroll account menu button into view before clicking

--- a/src/wallets/metamask/actions/helpers/actions.ts
+++ b/src/wallets/metamask/actions/helpers/actions.ts
@@ -13,7 +13,9 @@ export const openNetworkDropdown = async (page: Page): Promise<void> => {
 };
 
 export const openAccountOptionsMenu = async (page: Page): Promise<void> => {
-  await page.getByTestId('account-options-menu-button').click();
+  const accountOptionsMenuButton = page.getByTestId('account-options-menu-button');
+  await accountOptionsMenuButton.scrollIntoViewIfNeeded();
+  await accountOptionsMenuButton.click();
 };
 
 export const openAccountMenu = async (page: Page): Promise<void> => {


### PR DESCRIPTION
**Short description of work done**

Being more explicit about the account menu button being in view before clicking to see if it helps with #426.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally

### Issues

#426
