### PR TITLE
chore: bumps metamask to 12.16.0

### DIFF
--- a/.changeset/six-wasps-work.md
+++ b/.changeset/six-wasps-work.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+chore: bumps metamask to 12.16.0

--- a/src/wallets/metamask/actions/helpers/selectors.ts
+++ b/src/wallets/metamask/actions/helpers/selectors.ts
@@ -7,7 +7,7 @@ export const getErrorMessage = async (page: Page): Promise<string | undefined> =
   try {
     const errorElement = await page.waitForSelector(`.mm-help-text.mm-box--color-error-default`, { timeout: 1000 });
     return await errorElement.innerText();
-  } catch (error) {
+  } catch (_) {
     return undefined;
   }
 };

--- a/src/wallets/metamask/actions/importPk.ts
+++ b/src/wallets/metamask/actions/importPk.ts
@@ -11,7 +11,7 @@ export const importPk =
 
     await page.getByTestId('multichain-account-menu-popover-action-button').click();
 
-    await clickOnButton(page, 'Import account');
+    await page.getByTestId('multichain-account-menu-popover-add-imported-account').click();
     await typeOnInputField(page, 'your private key', privateKey);
     await page.getByTestId('import-account-confirm-button').click();
 

--- a/src/wallets/metamask/metamask.ts
+++ b/src/wallets/metamask/metamask.ts
@@ -34,7 +34,7 @@ import {
 
 export class MetaMaskWallet extends Wallet {
   static id = 'metamask' as WalletIdOptions;
-  static recommendedVersion = '12.14.2';
+  static recommendedVersion = '12.16.0';
   static releasesUrl = 'https://api.github.com/repos/metamask/metamask-extension/releases';
   static homePath = '/home.html';
 


### PR DESCRIPTION
**Short description of work done**

Bumps Metamask to 12.16.0.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally

### Issues

Hopes this helps with #426 