### PR TITLE
chore: clearer worker downloader logging

### DIFF
--- a/.changeset/tricky-sloths-move.md
+++ b/.changeset/tricky-sloths-move.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+chore: clearer worker downloader logging

--- a/src/downloader/github.ts
+++ b/src/downloader/github.ts
@@ -46,7 +46,6 @@ export const getGithubRelease = (releasesUrl: string, version: string): Promise<
   });
 
 export const downloadGithubRelease = (name: string, url: string, location: string): Promise<string> =>
-  // eslint-disable-next-line no-async-promise-executor
   new Promise(async (resolve) => {
     if (!fs.existsSync(location)) {
       fs.mkdirSync(location, { recursive: true });

--- a/src/downloader/version.ts
+++ b/src/downloader/version.ts
@@ -20,7 +20,7 @@ export const printVersion = (walletId: WalletIdOptions, version: string, recomme
       `Seems you are running an older version (${version}) of ${walletId} than recommended by the Dappwright team.
       Use it at your own risk or set the recommended version "${recommendedVersion}".`,
     );
-  else console.log(`Running tests on ${walletId} version ${version}`);
+  else console.log(`Using ${walletId} v${version}`);
 
   console.log(''); // new line
 };


### PR DESCRIPTION
**Short description of work done**

When running multiple projects at the same time, the logging for the downloader can be too generic which makes it hard to debug failure scenarios.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally