### PR TITLE
fix(metamask): race condition leads to acquiring dormant page context

### DIFF
--- a/.changeset/nine-mirrors-rest.md
+++ b/.changeset/nine-mirrors-rest.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+fix(metamask): race condition can lead to acquiring dormant page context

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,13 +1,14 @@
 import { BrowserContext, Page } from 'playwright-core';
 import { launch } from './launch';
 import { Dappwright, OfficialOptions } from './types';
-import { getWallet, WalletOptions } from './wallets/wallets';
+import { closeWalletSetupPopup, getWallet, WalletOptions } from './wallets/wallets';
 
 export const bootstrap = async (
   browserName: string,
   { seed, password, showTestNets, ...launchOptions }: OfficialOptions & WalletOptions,
 ): Promise<[Dappwright, Page, BrowserContext]> => {
   const { browserContext } = await launch(browserName, launchOptions);
+  closeWalletSetupPopup(launchOptions.wallet, browserContext);
   const wallet = await getWallet(launchOptions.wallet, browserContext);
   await wallet.setup({ seed, password, showTestNets });
 

--- a/src/wallets/wallets.ts
+++ b/src/wallets/wallets.ts
@@ -24,25 +24,26 @@ export const getWalletType = (id: WalletIdOptions): WalletTypes => {
   return walletType;
 };
 
+export const closeWalletSetupPopup = (id: WalletIdOptions, browserContext: BrowserContext): void => {
+  browserContext.on('page', async (page) => {
+    if (page.url() === walletHomeUrl(id)) {
+      await page.close();
+    }
+  });
+};
+
 export const getWallet = async (id: WalletIdOptions, browserContext: BrowserContext): Promise<MetaMaskWallet> => {
   const wallet = getWalletType(id);
+  const page = browserContext.pages()[0];
 
-  if (browserContext.pages().length === 1) {
-    let page: Page;
-    try {
-      // Wait for the wallet to pop up
-      page = await browserContext.waitForEvent('page', { timeout: 2000 });
-      await browserContext.pages()[0].close();
-      return new wallet(page);
-    } catch {
-      // Open the wallet manually if tab doesn't pop up
-      page = browserContext.pages()[0];
-      await page.goto(`chrome-extension://${EXTENSION_ID}${wallet.homePath}`);
-    }
-
-    return new wallet(page);
+  if (page.url() === 'about:blank') {
+    await page.goto(walletHomeUrl(id));
   }
 
-  const page = browserContext.pages()[0];
   return new wallet(page);
+};
+
+const walletHomeUrl = (id: WalletIdOptions): string => {
+  const wallet = getWalletType(id);
+  return `chrome-extension://${EXTENSION_ID}${wallet.homePath}`;
 };


### PR DESCRIPTION
**Short description of work done**

Slower CI cycles means that dappwright could possibly timeout on waiting for a new metamask setup screen, move on, then the screen popups up as an option for acquisition later on in the cycle.

Which would explain why in #426 it fails on the first action after bootstrap.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally

### Issues

Closes #426 
