### PR TITLE
chore: bumps supported node version to >= 20

### DIFF
--- a/.changeset/plenty-bugs-learn.md
+++ b/.changeset/plenty-bugs-learn.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+chore: bumps supported node version to >= 20

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 18
+      - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Dependencies
         run: yarn

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,11 +13,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 18
+      - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18
+          node-version: 20
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -33,11 +33,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 18
+      - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18
+          node-version: 20
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dist/"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "scripts": {
     "prebuild": "rimraf dist",


### PR DESCRIPTION
**Short description of work done**

Bumps the supported node version to >= 20.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally
