### PR TITLE
chore: opt to click close buttons instead of the metamask logo to return home

### DIFF
--- a/.changeset/lemon-buttons-invite.md
+++ b/.changeset/lemon-buttons-invite.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+chore(metamask): opt to click close buttons instead of the metamask logo to return home

--- a/src/wallets/metamask/actions/addToken.ts
+++ b/src/wallets/metamask/actions/addToken.ts
@@ -1,7 +1,6 @@
 import { Page } from 'playwright-core';
 import { clickOnButton } from '../../../helpers';
 import { AddToken } from '../../../types';
-import { clickOnLogo } from './helpers';
 
 export const addToken =
   (page: Page) =>
@@ -25,5 +24,4 @@ export const addToken =
 
     await clickOnButton(page, 'Next');
     await page.getByTestId('import-tokens-modal-import-button').click();
-    await clickOnLogo(page);
   };

--- a/src/wallets/metamask/actions/helpers/actions.ts
+++ b/src/wallets/metamask/actions/helpers/actions.ts
@@ -21,8 +21,3 @@ export const openAccountOptionsMenu = async (page: Page): Promise<void> => {
 export const openAccountMenu = async (page: Page): Promise<void> => {
   await page.getByTestId('account-menu-icon').click();
 };
-
-export const clickOnLogo = async (page: Page): Promise<void> => {
-  const header = await page.waitForSelector('.app-header__logo-container');
-  await header.click();
-};

--- a/src/wallets/metamask/setup/setupActions.ts
+++ b/src/wallets/metamask/setup/setupActions.ts
@@ -2,7 +2,7 @@ import { Page } from 'playwright-core';
 
 import { clickOnButton, typeOnInputField, waitForChromeState } from '../../../helpers';
 import { WalletOptions } from '../../wallets';
-import { clickOnLogo, clickOnSettingsSwitch, openAccountOptionsMenu } from '../actions/helpers';
+import { clickOnSettingsSwitch, openAccountOptionsMenu } from '../actions/helpers';
 
 export async function goToSettings(metamaskPage: Page): Promise<void> {
   await openAccountOptionsMenu(metamaskPage);
@@ -14,7 +14,7 @@ export async function adjustSettings(metamaskPage: Page): Promise<void> {
   await metamaskPage.locator('.tab-bar__tab', { hasText: 'Advanced' }).click();
 
   await clickOnSettingsSwitch(metamaskPage, 'Show test networks');
-  await clickOnLogo(metamaskPage);
+  await metamaskPage.getByRole('button', { name: 'Close' }).click();
 
   await waitForChromeState(metamaskPage);
 }


### PR DESCRIPTION
**Short description of work done**

This replaces the "clickOnLogo" helper function for MetaMask with code to click the close button on screens that don't automatically return to the home screen after an action.

### PR Checklist
- [x] I have run linter locally
- [x] I have run unit and integration tests locally

### Issues

Closes #466 
