### PR TITLE
chore: adjusts the matching for downloaded versions more explicit

### DIFF
--- a/.changeset/friendly-countries-listen.md
+++ b/.changeset/friendly-countries-listen.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+chore: adjusts the matching for downloaded versions more explicit

--- a/src/downloader/downloader.ts
+++ b/src/downloader/downloader.ts
@@ -54,7 +54,7 @@ const download = async (
   // eslint-disable-next-line no-console
   console.info(`Downloading ${walletId}...`);
 
-  const { filename, downloadUrl } = await getGithubRelease(releasesUrl, `v${version}`);
+  const { filename, downloadUrl } = await getGithubRelease(releasesUrl, version);
 
   if (!fs.existsSync(downloadPath) || isEmpty(downloadPath)) {
     const walletFolder = downloadPath.split('/').slice(0, -1).join('/');


### PR DESCRIPTION
**Short description of work done**

There are more variants of chrome extensions coming out these days. Tightening up the matching logic for download extensions will ensure things remain deterministic.

### PR Checklist
- [x] I have run linter locally
- [x] I have run unit and integration tests locally

### Issues

Might be slightly related to the resolution to #473 