### PR TITLE
fix: moves multi-tab listener before first getWallet call

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,15 +1,14 @@
 import { BrowserContext, Page } from 'playwright-core';
 import { launch } from './launch';
 import { Dappwright, OfficialOptions } from './types';
-import { closeWalletSetupPopup, getWallet, WalletOptions } from './wallets/wallets';
+import { WalletOptions } from './wallets/wallets';
 
 export const bootstrap = async (
   browserName: string,
   { seed, password, showTestNets, ...launchOptions }: OfficialOptions & WalletOptions,
 ): Promise<[Dappwright, Page, BrowserContext]> => {
-  const { browserContext } = await launch(browserName, launchOptions);
-  closeWalletSetupPopup(launchOptions.wallet, browserContext);
-  const wallet = await getWallet(launchOptions.wallet, browserContext);
+  const { browserContext, wallet } = await launch(browserName, launchOptions);
+
   await wallet.setup({ seed, password, showTestNets });
 
   return [wallet, wallet.page, browserContext];

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import playwright from 'playwright-core';
 
 import { DappwrightLaunchResponse, OfficialOptions } from './types';
-import { getWallet, getWalletType } from './wallets/wallets';
+import { closeWalletSetupPopup, getWallet, getWalletType } from './wallets/wallets';
 
 /**
  * Launch Playwright chromium instance with wallet plugin installed
@@ -36,6 +36,8 @@ export async function launch(browserName: string, options: OfficialOptions): Pro
     headless: false,
     args: browserArgs,
   });
+
+  closeWalletSetupPopup(wallet.id, browserContext);
 
   return {
     wallet: await getWallet(wallet.id, browserContext),


### PR DESCRIPTION
**Short description of work done**

Fixes the issue where there are two wallet tabs open and the dormant one covers/hides the activity of the primary tab.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally