### PR TITLE
chore: fixes some build dep warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "microbundle --tsconfig tsconfig.build.json --external os,https,zlib,stream",
-    "dev": "microbundle --tsconfig tsconfig.build.json --external os,https,zlib,stream watch",
+    "build": "microbundle --tsconfig tsconfig.build.json --external os,https,zlib,stream,util,events,path",
+    "dev": "microbundle --tsconfig tsconfig.build.json --external os,https,zlib,stream,util,events,path watch",
     "lint": "yarn run lint:code && yarn run lint:unused",
     "lint:fix": "yarn run lint:code --fix",
     "lint:code": "eslint",


### PR DESCRIPTION
**Short description of work done**

Fixes some build warnings in regards to external dependencies. Would like to revamp build but just doing some chores atm.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally