### PR TITLE
fix: larger pagination window for github releases

### DIFF
--- a/.changeset/eighty-moose-train.md
+++ b/.changeset/eighty-moose-train.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+fix: larger pagination window for github releases

--- a/src/downloader/github.ts
+++ b/src/downloader/github.ts
@@ -26,7 +26,9 @@ export const getGithubRelease = (releasesUrl: string, version: string): Promise<
     const options = { headers: { 'User-Agent': 'Mozilla/5.0' } };
 
     if (process.env.GITHUB_TOKEN) options.headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
-    const request = get(releasesUrl, options, (response) => {
+    const url = new URL(releasesUrl);
+    url.searchParams.set('per_page', '100');
+    const request = get(url.toString(), options, (response) => {
       let body = '';
       response.on('data', (chunk) => {
         body += chunk;


### PR DESCRIPTION
**Short description of work done**

Given a certain newer releases, pinned version might fall out of the pagination window on the first page. While going through all the pages to get an older version isn't the best behaviour when testing wallets, opening up the window gives us a bit more breathing room as wallets continue to make major changes that take time to adapt to.

### PR Checklist
- [x] I have run linter locally
- [x] I have run unit and integration tests locally

### Issues

Closes #506 #507 
