### PR TITLE
fix: increased timeout for error message selector

### DIFF
--- a/.changeset/cruel-shirts-itch.md
+++ b/.changeset/cruel-shirts-itch.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+fix: increased timeout for error message selector

--- a/src/wallets/metamask/actions/helpers/selectors.ts
+++ b/src/wallets/metamask/actions/helpers/selectors.ts
@@ -5,7 +5,7 @@ export const getSettingsSwitch = (page: Page, text: string): Promise<ElementHand
 
 export const getErrorMessage = async (page: Page): Promise<string | undefined> => {
   try {
-    const errorElement = await page.waitForSelector(`.mm-help-text.mm-box--color-error-default`, { timeout: 1000 });
+    const errorElement = await page.waitForSelector(`.mm-help-text.mm-box--color-error-default`, { timeout: 5000 });
     return await errorElement.innerText();
   } catch (_) {
     return undefined;


### PR DESCRIPTION
**Short description of work done**

A bit more of a time buffer for the error message selector to help out with action stability.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally