### PR TITLE
fix: additional support for handling newer metamask popups

### DIFF
--- a/.changeset/lovely-memes-hear.md
+++ b/.changeset/lovely-memes-hear.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+fix: additional support for handling newer metamask popups

--- a/src/wallets/metamask/actions/network.ts
+++ b/src/wallets/metamask/actions/network.ts
@@ -1,6 +1,7 @@
 import { Page } from 'playwright-core';
 import { clickOnButton, clickOnElement, performSidepanelAction, waitForChromeState } from '../../../helpers';
 import { AddNetwork, UpdateNetworkRpc } from '../../../types';
+import { closePopup } from '../setup/setupActions';
 import { getErrorMessage, networkListItem, openNetworkDropdown, openNetworkSettings } from './helpers';
 
 export const switchNetwork =
@@ -40,19 +41,10 @@ export const addNetwork =
 
     // This popup is fairly random in terms of timing
     // and can show before switch to network click is gone
-    const gotItClick = (): Promise<void> =>
-      page.waitForTimeout(2000).then(() =>
-        page
-          .locator('button', { hasText: 'Got it' })
-          .isVisible()
-          .then((gotItButtonVisible) => {
-            if (gotItButtonVisible) return clickOnButton(page, 'Got it');
-            return Promise.resolve();
-          }),
-      );
+    await closePopup(page);
 
     await waitForChromeState(page);
-    await Promise.all([switchNetwork(page)(networkName), gotItClick()]);
+    await switchNetwork(page)(networkName);
   };
 
 export const deleteNetwork =

--- a/src/wallets/metamask/setup/setupActions.ts
+++ b/src/wallets/metamask/setup/setupActions.ts
@@ -41,6 +41,10 @@ export const closePopup = async (page: Page): Promise<void> => {
   if (await page.getByTestId('popover-close').isVisible()) {
     await page.getByTestId('popover-close').click();
   }
+  const notNowButton = page.getByRole('button', { name: 'Not now' });
+  if (await notNowButton.isVisible()) {
+    await notNowButton.click();
+  }
 };
 
 export async function adjustSettings(metamaskPage: Page): Promise<void> {


### PR DESCRIPTION
**Short description of work done**

Metamask has some newer popups that show up in some in some unexpected parts of the experience. This addresses that behaviour.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally