### PR TITLE
chore: bumps Coinbase wallet from v3.123.0 to v3.136.0

### DIFF
--- a/.changeset/neat-trams-unite.md
+++ b/.changeset/neat-trams-unite.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+chore: bumps Coinbase wallet from v3.123.0 to v3.136.0

--- a/src/wallets/coinbase/coinbase.ts
+++ b/src/wallets/coinbase/coinbase.ts
@@ -29,7 +29,7 @@ import { navigateHome } from './actions/helpers';
 
 export class CoinbaseWallet extends Wallet {
   static id = 'coinbase' as WalletIdOptions;
-  static recommendedVersion = '3.123.0';
+  static recommendedVersion = '3.136.0';
   static releasesUrl = 'https://api.github.com/repos/TenKeyLabs/coinbase-wallet-archive/releases';
   static homePath = '/index.html';
 


### PR DESCRIPTION
**Short description of work done**

bumps Coinbase wallet from v3.123.0 to v3.136.0

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally