### PR TITLE
fix(metamask): commit final SRP word so import Continue button enables

### DIFF
--- a/.changeset/srp-import-commit-last-word.md
+++ b/.changeset/srp-import-commit-last-word.md
@@ -1,0 +1,5 @@
+---
+"@tenkeylabs/dappwright": patch
+---
+
+fix(metamask): commit the final SRP word during import so the Continue button enables on MetaMask 13.17. After `pressSequentially(seed)` the last word could stay uncommitted, leaving `import-srp-confirm` disabled and timing out the click. Press Space on the SRP input to validate the full phrase.

--- a/src/wallets/metamask/setup/setupActions.ts
+++ b/src/wallets/metamask/setup/setupActions.ts
@@ -15,6 +15,11 @@ export async function importAccount(
   // Continue button. Without a trailing separator the last word can stay
   // uncommitted and `import-srp-confirm` remains disabled (seen on MetaMask
   // 13.17.0), making the click below time out.
+  //
+  // Use the global keyboard rather than `locator.press` on the SRP field:
+  // after `pressSequentially` the focus is already on that input, and the
+  // `srp-input-import__srp-note` testid is no longer re-locatable at this
+  // point, so a locator-based press times out waiting for the element.
   await metamaskPage.keyboard.press('Space');
   await metamaskPage.getByTestId('import-srp-confirm').click();
 }

--- a/src/wallets/metamask/setup/setupActions.ts
+++ b/src/wallets/metamask/setup/setupActions.ts
@@ -11,6 +11,11 @@ export async function importAccount(
   await metamaskPage.getByTestId('onboarding-import-wallet').click();
   await metamaskPage.getByTestId('onboarding-import-with-srp-button').click();
   await metamaskPage.getByTestId('srp-input-import__srp-note').pressSequentially(seed, { delay: 30 });
+  // Commit the final word so MetaMask validates the full SRP and enables the
+  // Continue button. Without a trailing separator the last word can stay
+  // uncommitted and `import-srp-confirm` remains disabled (seen on MetaMask
+  // 13.17.0), making the click below time out.
+  await metamaskPage.keyboard.press('Space');
   await metamaskPage.getByTestId('import-srp-confirm').click();
 }
 


### PR DESCRIPTION
## Problem

`importAccount` (used by `bootstrap()` / `MetaMaskWallet.setup`) can hang during onboarding: after typing the seed into `srp-input-import__srp-note` with `pressSequentially`, MetaMask 13.17 leaves the **Continue** button (`import-srp-confirm`) `disabled`, so the following click times out with `element is not enabled`.

Fixes #559.

## Root cause

MetaMask 13.17's single SRP textarea validates the phrase only once the **last word is committed** (a trailing separator / final input event). `pressSequentially(seed)` ends right after the 12th word with no trailing space, leaving the final word uncommitted and Continue disabled.

Verified against MetaMask 13.17.0 with a valid 12-word test mnemonic:

- `fill(seed)` and `fill(seed + ' ')` → Continue stays **disabled**
- `pressSequentially(seed)` then `keyboard.press('Space')` → Continue **enabled** ✅

## Change

One line in `src/wallets/metamask/setup/setupActions.ts`: press Space after typing the seed to commit the final word. It's deterministic and has no side effect on setups where the import already succeeds.

```ts
await metamaskPage.getByTestId('srp-input-import__srp-note').pressSequentially(seed, { delay: 30 });
await metamaskPage.keyboard.press('Space');
await metamaskPage.getByTestId('import-srp-confirm').click();
```

This is likely timing-sensitive (slower machines are more prone to it, which may be why CI is green today).
