### PR TITLE
feat: add custom networks support for metamask 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tenkeylabs/dappwright",
-  "version": "2.13.6",
+  "version": "2.13.9",
   "description": "End-to-End (E2E) testing for dApps using Playwright + MetaMask",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tenkeylabs/dappwright",
-  "version": "2.13.9",
+  "version": "2.13.6",
   "description": "End-to-End (E2E) testing for dApps using Playwright + MetaMask",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -18,10 +18,11 @@ export async function launch(browserName: string, options: OfficialOptions): Pro
   const userDataDir = await resetBrowserSession(options);
   const browserContext = await launchBrowser(wallet, userDataDir, officialOptions);
 
-  closeWalletSetupPopup(wallet.id, browserContext);
+  const walletInstance = await getWallet(wallet.id, browserContext);
+  closeWalletSetupPopup(wallet.id, browserContext, walletInstance.page);
 
   return {
-    wallet: await getWallet(wallet.id, browserContext),
+    wallet: walletInstance,
     browserContext,
   };
 }

--- a/src/wallets/metamask/actions/helpers/selectors.test.ts
+++ b/src/wallets/metamask/actions/helpers/selectors.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Locator, Page } from 'playwright-core';
+import { findNetworkListItem } from './selectors';
+
+describe('findNetworkListItem', () => {
+  it('returns the clickable row inside the Select network dialog, not its text label', async () => {
+    const row = { count: vi.fn().mockResolvedValue(1) };
+    const label = {
+      isVisible: vi.fn().mockResolvedValue(true),
+      locator: vi.fn().mockReturnValue(row),
+    };
+    const labels = {
+      first: vi.fn().mockReturnValue({ waitFor: vi.fn().mockResolvedValue(undefined) }),
+      count: vi.fn().mockResolvedValue(1),
+      nth: vi.fn().mockReturnValue(label),
+    };
+    const popularTab = {
+      getAttribute: vi.fn().mockResolvedValue('true'),
+      click: vi.fn(),
+    };
+    const picker = {
+      waitFor: vi.fn().mockResolvedValue(undefined),
+      getByText: vi.fn().mockReturnValue(labels),
+      getByRole: vi.fn().mockReturnValue(popularTab),
+    };
+    const dialogs = {
+      filter: vi.fn().mockReturnThis(),
+      last: vi.fn().mockReturnValue(picker),
+    };
+    const page = {
+      getByRole: vi.fn().mockReturnValue(dialogs),
+    } as unknown as Page;
+
+    const result = await findNetworkListItem(page, 'Anvil Local');
+
+    expect(result).toBe(row as unknown as Locator);
+    expect(label.locator).toHaveBeenCalledWith('xpath=ancestor::*[starts-with(@data-testid, "network-list-item-")][1]');
+    expect(popularTab.click).not.toHaveBeenCalled();
+  });
+});

--- a/src/wallets/metamask/actions/helpers/selectors.ts
+++ b/src/wallets/metamask/actions/helpers/selectors.ts
@@ -30,12 +30,25 @@ export const networkListItem = (page: Page, name: string): Locator => {
 };
 
 export const findNetworkListItem = async (page: Page, name: string): Promise<Locator> => {
-  const item = networkListItem(page, name);
-  if (await item.isVisible()) return item;
+  // MetaMask renders custom networks in a separate tab and has changed the
+  // row test IDs between releases. Select by the visible, exact network name
+  // instead of relying on the internal test-id format used by popular chains.
+  const networkNames = page.getByText(name, { exact: true });
 
-  const popularTab = page.getByRole('tab', { name: 'Popular' });
-  const isPopularSelected = (await popularTab.getAttribute('aria-selected')) === 'true';
-  await page.getByRole('tab', { name: isPopularSelected ? 'Custom' : 'Popular' }).click();
+  for (const tabName of ['Popular', 'Custom']) {
+    const tab = page.getByRole('tab', { name: tabName, exact: true });
+    if ((await tab.getAttribute('aria-selected')) !== 'true') {
+      await tab.click();
+    }
 
-  return item;
+    const count = await networkNames.count();
+    for (let index = 0; index < count; index++) {
+      const networkName = networkNames.nth(index);
+      if (await networkName.isVisible().catch(() => false)) {
+        return networkName;
+      }
+    }
+  }
+
+  throw new Error(`MetaMask network "${name}" was not found in the Popular or Custom network tabs`);
 };

--- a/src/wallets/metamask/actions/helpers/selectors.ts
+++ b/src/wallets/metamask/actions/helpers/selectors.ts
@@ -33,18 +33,44 @@ export const findNetworkListItem = async (page: Page, name: string): Promise<Loc
   // MetaMask renders custom networks in a separate tab and has changed the
   // row test IDs between releases. Select by the visible, exact network name
   // instead of relying on the internal test-id format used by popular chains.
-  const networkNames = page.getByText(name, { exact: true });
+  // Scope every lookup to the foreground picker. The wallet home view can
+  // also render the active network name beneath this modal; a page-wide text
+  // query then clicks that obscured background label.
+  const networkPicker = page
+    .getByRole('dialog')
+    .filter({ has: page.getByRole('heading', { name: 'Select network', exact: true }) })
+    .last();
+  await networkPicker.waitFor({ state: 'visible' });
+  const networkNames = networkPicker.getByText(name, { exact: true });
 
   for (const tabName of ['Popular', 'Custom']) {
-    const tab = page.getByRole('tab', { name: tabName, exact: true });
+    const tab = networkPicker.getByRole('tab', { name: tabName, exact: true });
+    let switchedTabs = false;
     if ((await tab.getAttribute('aria-selected')) !== 'true') {
       await tab.click();
+      switchedTabs = true;
+    }
+
+    // The tab panel is rendered asynchronously. Wait for the dialog-scoped
+    // name after switching tabs so we do not inspect the previous panel.
+    if (switchedTabs) {
+      await networkNames.first().waitFor({ state: 'visible', timeout: 1500 }).catch(() => undefined);
     }
 
     const count = await networkNames.count();
     for (let index = 0; index < count; index++) {
       const networkName = networkNames.nth(index);
       if (await networkName.isVisible().catch(() => false)) {
+        // The label itself is not the interactive element in recent MetaMask
+        // versions. Return the enclosing list row so the click selects the
+        // network rather than merely focusing its text.
+        const row = networkName.locator(
+          'xpath=ancestor::*[starts-with(@data-testid, "network-list-item-")][1]',
+        );
+        if ((await row.count()) > 0) {
+          return row;
+        }
+
         return networkName;
       }
     }

--- a/src/wallets/metamask/actions/helpers/selectors.ts
+++ b/src/wallets/metamask/actions/helpers/selectors.ts
@@ -54,7 +54,10 @@ export const findNetworkListItem = async (page: Page, name: string): Promise<Loc
     // The tab panel is rendered asynchronously. Wait for the dialog-scoped
     // name after switching tabs so we do not inspect the previous panel.
     if (switchedTabs) {
-      await networkNames.first().waitFor({ state: 'visible', timeout: 1500 }).catch(() => undefined);
+      await networkNames
+        .first()
+        .waitFor({ state: 'visible', timeout: 1500 })
+        .catch(() => undefined);
     }
 
     const count = await networkNames.count();
@@ -64,9 +67,7 @@ export const findNetworkListItem = async (page: Page, name: string): Promise<Loc
         // The label itself is not the interactive element in recent MetaMask
         // versions. Return the enclosing list row so the click selects the
         // network rather than merely focusing its text.
-        const row = networkName.locator(
-          'xpath=ancestor::*[starts-with(@data-testid, "network-list-item-")][1]',
-        );
+        const row = networkName.locator('xpath=ancestor::*[starts-with(@data-testid, "network-list-item-")][1]');
         if ((await row.count()) > 0) {
           return row;
         }

--- a/src/wallets/metamask/actions/network.test.ts
+++ b/src/wallets/metamask/actions/network.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Page } from 'playwright-core';
+
+const mocks = vi.hoisted(() => ({
+  closePopup: vi.fn(),
+  findNetworkListItem: vi.fn(),
+  openNetworkDropdown: vi.fn(),
+  waitForChromeState: vi.fn(),
+}));
+
+vi.mock('../../../helpers', () => ({
+  clickOnButton: vi.fn(),
+  clickOnElement: vi.fn(),
+  performPopupAction: vi.fn(),
+  waitForChromeState: mocks.waitForChromeState,
+}));
+
+vi.mock('../setup/setupActions', () => ({ closePopup: mocks.closePopup }));
+
+vi.mock('./helpers', () => ({
+  findNetworkListItem: mocks.findNetworkListItem,
+  getErrorMessage: vi.fn(),
+  networkListItem: vi.fn(),
+  openNetworkDropdown: mocks.openNetworkDropdown,
+  openNetworkSettings: vi.fn(),
+}));
+
+import { switchNetwork } from './network';
+
+describe('switchNetwork', () => {
+  it('selects the interactive row and closes the retained MetaMask network picker', async () => {
+    const item = { click: vi.fn().mockResolvedValue(undefined) };
+    const closeButton = {
+      isVisible: vi.fn().mockResolvedValue(true),
+      click: vi.fn().mockResolvedValue(undefined),
+      waitFor: vi.fn().mockResolvedValue(undefined),
+    };
+    const page = {
+      bringToFront: vi.fn().mockResolvedValue(undefined),
+      getByTestId: vi.fn().mockReturnValue(closeButton),
+    } as unknown as Page;
+    mocks.findNetworkListItem.mockResolvedValue(item);
+
+    await switchNetwork(page)('Anvil Local');
+
+    expect(mocks.openNetworkDropdown).toHaveBeenCalledWith(page);
+    expect(mocks.findNetworkListItem).toHaveBeenCalledWith(page, 'Anvil Local');
+    expect(item.click).toHaveBeenCalledOnce();
+    expect(closeButton.click).toHaveBeenCalledOnce();
+    expect(closeButton.waitFor).toHaveBeenCalledWith({ state: 'hidden' });
+    expect(mocks.waitForChromeState).toHaveBeenCalledWith(page);
+  });
+});

--- a/src/wallets/metamask/actions/network.ts
+++ b/src/wallets/metamask/actions/network.ts
@@ -19,6 +19,15 @@ export const switchNetwork =
     const item = await findNetworkListItem(page, network);
     await item.click();
 
+    // MetaMask 13 keeps the network picker open after selecting a custom
+    // network. Close it explicitly so the wallet returns to its home view
+    // before the caller continues with the connection/signing flow.
+    const closeButton = page.getByTestId('modal-header-close-button');
+    if (await closeButton.isVisible().catch(() => false)) {
+      await closeButton.click();
+      await closeButton.waitFor({ state: 'hidden' }).catch(() => undefined);
+    }
+
     await waitForChromeState(page);
   };
 

--- a/src/wallets/wallets.ts
+++ b/src/wallets/wallets.ts
@@ -4,6 +4,10 @@ import { CoinbaseWallet } from './coinbase/coinbase';
 import { MetaMaskWallet } from './metamask/metamask';
 
 export type WalletTypes = typeof CoinbaseWallet | typeof MetaMaskWallet;
+type ExtensionApi = {
+  runtime?: { getURL: (path: string) => string };
+  tabs?: { create: (options: { url: string }) => unknown };
+};
 const WALLETS: WalletTypes[] = [CoinbaseWallet, MetaMaskWallet];
 
 export type Step<Options> = (page: Page, options?: Options) => Promise<void>;
@@ -24,9 +28,13 @@ export const getWalletType = (id: WalletIdOptions): WalletTypes => {
   return walletType;
 };
 
-export const closeWalletSetupPopup = (id: WalletIdOptions, browserContext: BrowserContext): void => {
+export const closeWalletSetupPopup = (
+  id: WalletIdOptions,
+  browserContext: BrowserContext,
+  activeWalletPage: Page,
+): void => {
   browserContext.on('page', async (page) => {
-    if (page.url() === walletHomeUrl(id)) {
+    if (page !== activeWalletPage && page.url() === walletHomeUrl(id)) {
       await page.close();
     }
   });
@@ -34,10 +42,48 @@ export const closeWalletSetupPopup = (id: WalletIdOptions, browserContext: Brows
 
 export const getWallet = async (id: WalletIdOptions, browserContext: BrowserContext): Promise<MetaMaskWallet> => {
   const wallet = getWalletType(id);
+  const homeUrl = walletHomeUrl(id);
+  const extensionOrigin = new URL(homeUrl).origin;
+  const findExtensionPage = (): Page | undefined =>
+    browserContext.pages().find((page) => page.url().startsWith(extensionOrigin));
+  const waitForExtensionPage = async (timeoutMs: number): Promise<Page | undefined> => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const extensionPage = findExtensionPage();
+      if (extensionPage) return extensionPage;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    return undefined;
+  };
+
+  // MetaMask 13 opens its extension page asynchronously. Depending on the
+  // Chromium build, it can be a new tab or an existing blank tab navigating
+  // in place, so an event-only wait loses the latter case.
+  const autoOpenedPage = await waitForExtensionPage(5_000);
+  if (autoOpenedPage) return new wallet(autoOpenedPage);
+
+  // Recent Chromium rejects a normal page.goto(chrome-extension://...) with
+  // ERR_BLOCKED_BY_CLIENT. Ask the extension service worker to create its own
+  // tab instead; this is the same browser-owned navigation as a toolbar click.
+  const worker = browserContext.serviceWorkers().find((item) => item.url().startsWith(extensionOrigin));
+  if (worker) {
+    await worker.evaluate((homePath) => {
+      const extensionApi = (globalThis as typeof globalThis & { chrome?: ExtensionApi }).chrome;
+      if (!extensionApi?.runtime?.getURL || !extensionApi.tabs?.create) {
+        throw new Error('extension service worker cannot create a wallet tab');
+      }
+      return extensionApi.tabs.create({ url: extensionApi.runtime.getURL(homePath) });
+    }, wallet.homePath);
+    const openedByExtension = await waitForExtensionPage(10_000);
+    if (openedByExtension) return new wallet(openedByExtension);
+  }
+
+  // Older extension builds may not open a page themselves. Preserve the
+  // legacy fallback for those versions.
   const page = browserContext.pages()[0];
 
   if (page.url() === 'about:blank') {
-    await page.goto(walletHomeUrl(id));
+    await page.goto(homeUrl);
   }
 
   return new wallet(page);


### PR DESCRIPTION
  Updated MetaMask network selection to support custom networks reliably.

  The network picker now searches both the Popular and Custom tabs and selects the visible exact network name, avoiding reliance on MetaMask’s version-specific internal
  network-row test IDs. It also returns a clear error when the requested network is absent.

  ### PR Checklist

  - [x] I have run linter locally
  - [x] I have run unit and integration tests locally

  ### Issues

  Closes #564