### PR TITLE
fix(coinbase): wait for or bypass the recovery phrase warning dialog when bootstrapping

### DIFF
--- a/.changeset/plain-cameras-joke.md
+++ b/.changeset/plain-cameras-joke.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+fix(coinbase): wait for or bypass the recovery phrase warning dialog when bootstrapping

--- a/src/wallets/coinbase/actions/setup.ts
+++ b/src/wallets/coinbase/actions/setup.ts
@@ -15,7 +15,18 @@ export async function getStarted(
 
   // Import Wallet
   await page.getByTestId('btn-import-recovery-phrase').click();
-  await page.getByRole('button', { name: 'Acknowledge' }).click();
+
+  // The recovery phrase warning modal only renders if the import screen has
+  // settled before we click through - clicking it mid-transition lands on the
+  // import screen with no modal at all. Wait for the screen, then dismiss the
+  // modal only if it actually showed up, otherwise we block until the fixture
+  // times out waiting for a button that is never coming.
+  await page.getByTestId('secret-input').waitFor();
+  await page
+    .getByRole('button', { name: 'Acknowledge' })
+    .click({ timeout: 5000 })
+    .catch(() => undefined);
+
   await page.getByTestId('secret-input').fill(seed);
   await page.getByTestId('btn-import-wallet').click();
   await page.getByTestId('setPassword').fill(password);


### PR DESCRIPTION
**Short description of work done**

<img width="654" height="556" alt="image" src="https://github.com/user-attachments/assets/7641f867-837e-4099-a16a-c94df8aee78c" />

The recovery phrase warning modal only renders if the import screen has settled before we click through - clicking it mid-transition lands on the import screen with no modal at all. Wait for the screen, then dismiss the modal only if it actually showed up, otherwise we block until the fixture times out waiting for a button that is never coming.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally