### PR TITLE
fix: coordinates concurrent extension downloads and runs wallet projects in parallel

### DIFF
--- a/.changeset/soft-moons-repeat.md
+++ b/.changeset/soft-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+fix: coordinates concurrent extension downloads to unlock the ability to run wallet projects in parallel

--- a/.changeset/tidy-donkeys-repeat.md
+++ b/.changeset/tidy-donkeys-repeat.md
@@ -1,0 +1,6 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+fix: waits for the downloaded extension archive to be flushed to disk before extracting it. Also follows all redirect statuses rather than only 302, and fails loudly on a non-200 response instead of writing the error body out as the archive
+fix: follows all redirect statuses rather than only 302, and fails loudly on a non-200 response instead of writing the error body out as the archive

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,6 +3,7 @@ import { CoinbaseWallet, MetaMaskWallet } from './src';
 
 export default defineConfig({
   testIgnore: '**/*.test.ts',
+  globalSetup: './test/helpers/globalSetup.ts',
   retries: process.env.CI ? 1 : 0,
   timeout: process.env.CI ? 120000 : 60000,
   use: {
@@ -19,6 +20,9 @@ export default defineConfig({
   projects: [
     {
       name: 'MetaMask',
+      // One browser per wallet: the spec files share a chain account, and a single worker also
+      // means the wallet is bootstrapped once for the project instead of once per file
+      workers: 1,
       metadata: {
         wallet: 'metamask',
         version: MetaMaskWallet.recommendedVersion,
@@ -28,13 +32,18 @@ export default defineConfig({
     },
     {
       name: 'Coinbase',
+      workers: 1,
       metadata: {
         wallet: 'coinbase',
         version: CoinbaseWallet.recommendedVersion,
         seed: 'pioneer casual canoe gorilla embrace width fiction bounce spy exhibit another dog',
         password: 'password1234!@#$',
+        // Both projects import this seed, and the test chain funds the accounts derived from
+        // it, so MetaMask and Coinbase would otherwise drive the same address. Pointing
+        // Coinbase at the second derived account - funded just like the first - keeps the two
+        // projects off each other's nonce while they run together.
+        account: 'Address 2',
       },
-      dependencies: ["MetaMask"],
     },
   ],
 });

--- a/src/downloader/constants.ts
+++ b/src/downloader/constants.ts
@@ -14,7 +14,16 @@ export const DOWNLOAD_STATE_FILES = {
   error: '.error',
 } as const;
 
+// Suffix for the directory used to claim ownership of a download
+export const DOWNLOAD_CLAIM_SUFFIX = '.claim';
+
 // Configuration constants
 export const DOWNLOAD_CONFIG = {
   pollIntervalMs: 2000,
+  // How often the claim holder touches the claim directory to signal it is still alive
+  heartbeatIntervalMs: 2000,
+  // A claim that hasn't been touched within this window is considered abandoned
+  staleClaimMs: 30000,
+  // Upper bound on how long a worker will wait for another worker's download
+  maxWaitMs: 600000,
 } as const;

--- a/src/downloader/downloader.test.ts
+++ b/src/downloader/downloader.test.ts
@@ -6,7 +6,7 @@ import os from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, MockedFunction, vi } from 'vitest';
 import { OfficialOptions } from '../types';
-import { DOWNLOAD_CONFIG, DOWNLOAD_STATE_FILES } from './constants';
+import { DOWNLOAD_CLAIM_SUFFIX, DOWNLOAD_CONFIG, DOWNLOAD_STATE_FILES } from './constants';
 import createWalletDownloader from './downloader';
 import { downloadDir } from './file';
 
@@ -65,18 +65,27 @@ describe('createWalletDownloader', () => {
     fs.writeFileSync(path.join(dir, fileName), content);
   };
 
+  // Simulate another worker holding the download claim
+  const claimDir = (): string => `${testDir}${DOWNLOAD_CLAIM_SUFFIX}`;
+  const holdClaim = (ageMs = 0): void => {
+    fs.mkdirSync(claimDir(), { recursive: true });
+    const touched = new Date(Date.now() - ageMs);
+    fs.utimesSync(claimDir(), touched, touched);
+  };
+  const releaseClaim = (): void => {
+    fs.rmSync(claimDir(), { recursive: true, force: true });
+  };
+
   beforeEach(() => {
     testDir = createTestDir();
     mockDownloadDir.mockReturnValue(testDir);
 
     // Reset all mocks
     vi.clearAllMocks();
-
-    // Reset environment variables
-    delete process.env.TEST_PARALLEL_INDEX;
   });
 
   afterEach(() => {
+    releaseClaim();
     cleanupTestDir(testDir);
   });
 
@@ -128,12 +137,8 @@ describe('createWalletDownloader', () => {
     });
   });
 
-  describe('primary worker download scenario', () => {
-    beforeEach(() => {
-      process.env.TEST_PARALLEL_INDEX = '0';
-    });
-
-    it('should perform download when primary worker and download not complete', async () => {
+  describe('claiming worker download scenario', () => {
+    it('should perform download when the claim is free and download not complete', async () => {
       const downloader = createWalletDownloader(mockWalletId, mockReleasesUrl, mockRecommendedVersion);
       const options: OfficialOptions = {
         wallet: 'metamask',
@@ -160,6 +165,9 @@ describe('createWalletDownloader', () => {
       // Verify success file was created
       const successFile = path.join(testDir, DOWNLOAD_STATE_FILES.success);
       expect(fs.existsSync(successFile)).toBe(true);
+
+      // Verify the claim was released for other workers
+      expect(fs.existsSync(claimDir())).toBe(false);
     });
 
     it('should skip download if already complete', async () => {
@@ -199,6 +207,9 @@ describe('createWalletDownloader', () => {
       // Verify downloading flag was cleaned up
       const downloadingFile = path.join(testDir, DOWNLOAD_STATE_FILES.downloading);
       expect(fs.existsSync(downloadingFile)).toBe(false);
+
+      // Verify the claim was released so another worker can retry
+      expect(fs.existsSync(claimDir())).toBe(false);
     });
 
     it('should handle extraction errors', async () => {
@@ -224,9 +235,10 @@ describe('createWalletDownloader', () => {
     });
   });
 
-  describe('secondary worker scenario', () => {
+  describe('waiting worker scenario', () => {
+    // Another worker already owns the download
     beforeEach(() => {
-      process.env.TEST_PARALLEL_INDEX = '1';
+      holdClaim();
     });
 
     it('should wait for download completion', async () => {
@@ -236,9 +248,10 @@ describe('createWalletDownloader', () => {
         version: mockVersion,
       };
 
-      // Simulate download completion after some time
+      // Simulate the claim holder completing the download
       setTimeout(() => {
         createStateFile(testDir, DOWNLOAD_STATE_FILES.success);
+        releaseClaim();
       }, 100);
 
       const result = await downloader(options);
@@ -247,7 +260,7 @@ describe('createWalletDownloader', () => {
       expect(mockGetGithubRelease).not.toHaveBeenCalled();
     });
 
-    it('should throw error when primary worker fails', async () => {
+    it('should throw error when the claim holder fails', async () => {
       const downloader = createWalletDownloader(mockWalletId, mockReleasesUrl, mockRecommendedVersion);
       const options: OfficialOptions = {
         wallet: 'metamask',
@@ -258,7 +271,7 @@ describe('createWalletDownloader', () => {
       createStateFile(testDir, DOWNLOAD_STATE_FILES.error, 'Download failed: Network timeout');
 
       await expect(downloader(options)).rejects.toThrow(
-        'Primary worker failed to download metamask: Download failed: Network timeout',
+        'Failed to download metamask: Download failed: Network timeout',
       );
     });
 
@@ -278,7 +291,7 @@ describe('createWalletDownloader', () => {
         fs.chmodSync(errorFile, 0o000);
 
         await expect(downloader(options)).rejects.toThrow(
-          'Primary worker failed to download metamask: Unknown error occurred during download',
+          'Failed to download metamask: Unknown error occurred during download',
         );
 
         // Restore permissions for cleanup
@@ -288,13 +301,84 @@ describe('createWalletDownloader', () => {
         return;
       }
     });
+
+    it('should take over the download when the claim holder gives up', async () => {
+      const downloader = createWalletDownloader(mockWalletId, mockReleasesUrl, mockRecommendedVersion);
+      const options: OfficialOptions = {
+        wallet: 'metamask',
+        version: mockVersion,
+      };
+
+      mockGetGithubRelease.mockResolvedValue({
+        filename: 'test.zip',
+        downloadUrl: 'https://example.com/test.zip',
+        tag: 'v12.16.0',
+      });
+      mockDownloadGithubRelease.mockResolvedValue('/tmp/test.zip');
+      mockExtractZip.mockResolvedValue();
+
+      // Claim released without a success or error marker
+      setTimeout(releaseClaim, 100);
+
+      const result = await downloader(options);
+
+      expect(result).toBe(testDir);
+      expect(mockGetGithubRelease).toHaveBeenCalledTimes(1);
+      expect(fs.existsSync(path.join(testDir, DOWNLOAD_STATE_FILES.success))).toBe(true);
+    });
+  });
+
+  describe('abandoned claim scenario', () => {
+    it('should take over a claim that has stopped reporting progress', async () => {
+      // Claim last touched well beyond the stale threshold, eg. a worker that was killed
+      holdClaim(DOWNLOAD_CONFIG.staleClaimMs * 2);
+
+      const downloader = createWalletDownloader(mockWalletId, mockReleasesUrl, mockRecommendedVersion);
+      const options: OfficialOptions = {
+        wallet: 'metamask',
+        version: mockVersion,
+      };
+
+      mockGetGithubRelease.mockResolvedValue({
+        filename: 'test.zip',
+        downloadUrl: 'https://example.com/test.zip',
+        tag: 'v12.16.0',
+      });
+      mockDownloadGithubRelease.mockResolvedValue('/tmp/test.zip');
+      mockExtractZip.mockResolvedValue();
+
+      const result = await downloader(options);
+
+      expect(result).toBe(testDir);
+      expect(mockGetGithubRelease).toHaveBeenCalledTimes(1);
+      expect(fs.existsSync(claimDir())).toBe(false);
+    });
+
+    it('should keep waiting on a claim that is still reporting progress', async () => {
+      holdClaim();
+
+      const downloader = createWalletDownloader(mockWalletId, mockReleasesUrl, mockRecommendedVersion);
+      const options: OfficialOptions = {
+        wallet: 'metamask',
+        version: mockVersion,
+      };
+
+      // Holder keeps the claim alive, then succeeds
+      const heartbeat = setInterval(() => holdClaim(), 50);
+      setTimeout(() => {
+        clearInterval(heartbeat);
+        createStateFile(testDir, DOWNLOAD_STATE_FILES.success);
+        releaseClaim();
+      }, DOWNLOAD_CONFIG.pollIntervalMs + 500);
+
+      const result = await downloader(options);
+
+      expect(result).toBe(testDir);
+      expect(mockGetGithubRelease).not.toHaveBeenCalled();
+    }, 11000);
   });
 
   describe('file system operations', () => {
-    beforeEach(() => {
-      process.env.TEST_PARALLEL_INDEX = '0';
-    });
-
     it('should prepare root directory correctly', async () => {
       // Create some existing content
       const existingFile = path.join(testDir, 'existing.txt');
@@ -394,8 +478,6 @@ describe('createWalletDownloader', () => {
     });
 
     it('should handle non-string error objects', async () => {
-      process.env.TEST_PARALLEL_INDEX = '0';
-
       const downloader = createWalletDownloader(mockWalletId, mockReleasesUrl, mockRecommendedVersion);
       const options: OfficialOptions = {
         wallet: 'metamask',
@@ -412,39 +494,15 @@ describe('createWalletDownloader', () => {
       expect(fs.existsSync(errorFile)).toBe(true);
       expect(fs.readFileSync(errorFile, 'utf-8')).toBe('[object Object]');
     });
-
-    it('should handle very long polling scenario', async () => {
-      process.env.TEST_PARALLEL_INDEX = '1';
-
-      const downloader = createWalletDownloader(mockWalletId, mockReleasesUrl, mockRecommendedVersion);
-      const options: OfficialOptions = {
-        wallet: 'metamask',
-        version: mockVersion,
-      };
-
-      // Mock a longer delay before marking as complete
-      setTimeout(() => {
-        createStateFile(testDir, DOWNLOAD_STATE_FILES.success);
-      }, DOWNLOAD_CONFIG.pollIntervalMs + 500);
-
-      const result = await downloader(options);
-
-      expect(result).toBe(testDir);
-    }, 11000); // Increased timeout to 10 seconds
   });
 
   describe('concurrent execution', () => {
-    it('should handle multiple downloaders running simultaneously', async () => {
-      process.env.TEST_PARALLEL_INDEX = '0';
+    const options: OfficialOptions = {
+      wallet: 'metamask',
+      version: mockVersion,
+    };
 
-      const downloader1 = createWalletDownloader(mockWalletId, mockReleasesUrl, mockRecommendedVersion);
-      const downloader2 = createWalletDownloader(mockWalletId, mockReleasesUrl, mockRecommendedVersion);
-
-      const options: OfficialOptions = {
-        wallet: 'metamask',
-        version: mockVersion,
-      };
-
+    beforeEach(() => {
       mockGetGithubRelease.mockResolvedValue({
         filename: 'test.zip',
         downloadUrl: 'https://example.com/test.zip',
@@ -452,12 +510,29 @@ describe('createWalletDownloader', () => {
       });
       mockDownloadGithubRelease.mockResolvedValue('/tmp/test.zip');
       mockExtractZip.mockResolvedValue();
+    });
+
+    it('should handle multiple downloaders running simultaneously', async () => {
+      const downloader1 = createWalletDownloader(mockWalletId, mockReleasesUrl, mockRecommendedVersion);
+      const downloader2 = createWalletDownloader(mockWalletId, mockReleasesUrl, mockRecommendedVersion);
 
       // Run both downloaders simultaneously
       const [result1, result2] = await Promise.all([downloader1(options), downloader2(options)]);
 
       expect(result1).toBe(testDir);
       expect(result2).toBe(testDir);
-    });
+    }, 11000);
+
+    it('should download exactly once regardless of which worker gets there first', async () => {
+      const downloaders = Array.from({ length: 5 }, () =>
+        createWalletDownloader(mockWalletId, mockReleasesUrl, mockRecommendedVersion),
+      );
+
+      const results = await Promise.all(downloaders.map((downloader) => downloader(options)));
+
+      expect(results).toEqual(Array(5).fill(testDir));
+      expect(mockGetGithubRelease).toHaveBeenCalledTimes(1);
+      expect(mockExtractZip).toHaveBeenCalledTimes(1);
+    }, 11000);
   });
 });

--- a/src/downloader/downloader.ts
+++ b/src/downloader/downloader.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { OfficialOptions } from '../types';
 import { WalletIdOptions } from '../wallets/wallets';
-import { DOWNLOAD_CONFIG, DOWNLOAD_STATE_FILES } from './constants';
+import { DOWNLOAD_CLAIM_SUFFIX, DOWNLOAD_CONFIG, DOWNLOAD_STATE_FILES } from './constants';
 import { downloadDir, editExtensionPubKey, extractZip } from './file';
 import { downloadGithubRelease, getGithubRelease } from './github';
 import { printVersion } from './version';
@@ -20,6 +20,7 @@ type DownloadResult = {
  */
 interface DownloadStatePaths {
   readonly rootDir: string;
+  readonly claimDir: string;
   readonly downloadingFile: string;
   readonly successFile: string;
   readonly errorFile: string;
@@ -55,14 +56,26 @@ async function downloadWalletExtension(
     return { path: paths.rootDir, wasDownloaded: false };
   }
 
-  if (isPrimaryWorker() && !isDownloadComplete(paths)) {
-    printVersion(walletId, version, recommendedVersion);
-    await performDownload(walletId, version, releasesUrl, paths);
-    return { path: paths.rootDir, wasDownloaded: true };
-  } else {
-    await waitForDownloadCompletion(walletId, paths);
-    return { path: paths.rootDir, wasDownloaded: false };
+  // Workers race for the claim rather than electing a downloader by worker index. Index based
+  // election breaks as soon as more than one wallet is downloaded concurrently (eg. parallel
+  // Playwright projects), since only one worker holds index 0 and every worker for the other
+  // wallet would wait on a download that is never started.
+  while (!isDownloadComplete(paths)) {
+    if (claimDownload(paths)) {
+      try {
+        printVersion(walletId, version, recommendedVersion);
+        await performDownload(walletId, version, releasesUrl, paths);
+      } finally {
+        releaseClaim(paths);
+      }
+      return { path: paths.rootDir, wasDownloaded: true };
+    }
+
+    // Lost the race. Wait for the holder, then re-check: the loop re-claims if it gave up.
+    await waitForClaimHolder(walletId, paths);
   }
+
+  return { path: paths.rootDir, wasDownloaded: false };
 }
 
 /**
@@ -76,6 +89,8 @@ async function performDownload(
 ): Promise<void> {
   prepareRootDir(paths);
   markDownloadStarted(paths);
+
+  const heartbeat = startClaimHeartbeat(paths);
 
   try {
     // eslint-disable-next-line no-console
@@ -93,6 +108,7 @@ async function performDownload(
     handleDownloadError(paths, error);
     throw error;
   } finally {
+    clearInterval(heartbeat);
     cleanupDownloadingFlag(paths);
   }
 }
@@ -103,10 +119,77 @@ async function performDownload(
 function createDownloadStatePaths(downloadPath: string): DownloadStatePaths {
   return {
     rootDir: downloadPath,
+    // Sits beside the download rather than inside it, since preparing the root wipes it
+    claimDir: `${downloadPath}${DOWNLOAD_CLAIM_SUFFIX}`,
     downloadingFile: path.join(downloadPath, DOWNLOAD_STATE_FILES.downloading),
     successFile: path.join(downloadPath, DOWNLOAD_STATE_FILES.success),
     errorFile: path.join(downloadPath, DOWNLOAD_STATE_FILES.error),
   };
+}
+
+/**
+ * Attempt to take ownership of the download.
+ *
+ * `mkdir` fails when the directory already exists, which makes it an atomic compare-and-set
+ * across processes - exactly one caller can win, no matter how many race for it.
+ */
+function claimDownload(paths: DownloadStatePaths): boolean {
+  fs.mkdirSync(path.dirname(paths.claimDir), { recursive: true });
+
+  try {
+    fs.mkdirSync(paths.claimDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    return false;
+  }
+
+  // Clear the previous attempt's failure before any waiter can observe it
+  deleteFileIfExists(paths.errorFile);
+  return true;
+}
+
+/**
+ * Release ownership of the download
+ */
+function releaseClaim(paths: DownloadStatePaths): void {
+  fs.rmSync(paths.claimDir, { recursive: true, force: true });
+}
+
+/**
+ * Check whether a claim is currently held
+ */
+function isClaimHeld(paths: DownloadStatePaths): boolean {
+  return fs.existsSync(paths.claimDir);
+}
+
+/**
+ * Check whether the claim holder has stopped reporting progress (eg. the process was killed)
+ */
+function isClaimStale(paths: DownloadStatePaths): boolean {
+  try {
+    return Date.now() - fs.statSync(paths.claimDir).mtimeMs > DOWNLOAD_CONFIG.staleClaimMs;
+  } catch {
+    // Released while we were looking at it
+    return false;
+  }
+}
+
+/**
+ * Touch the claim directory periodically so waiters can tell a slow download from a dead one
+ */
+function startClaimHeartbeat(paths: DownloadStatePaths): NodeJS.Timeout {
+  const heartbeat = setInterval(() => {
+    try {
+      const now = new Date();
+      fs.utimesSync(paths.claimDir, now, now);
+    } catch {
+      // Claim directory is gone - nothing to keep alive
+    }
+  }, DOWNLOAD_CONFIG.heartbeatIntervalMs);
+
+  // Don't hold the process open on the heartbeat alone
+  heartbeat.unref?.();
+  return heartbeat;
 }
 
 /**
@@ -205,25 +288,41 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Check if this is the primary worker responsible for downloading
+ * Wait for the worker holding the claim to finish downloading.
+ *
+ * Returns once the download succeeded, or once the claim is free again so the caller can take
+ * it over - either because the holder released it without succeeding, or because it went stale.
  */
-function isPrimaryWorker(): boolean {
-  return process.env.TEST_PARALLEL_INDEX === '0';
-}
+async function waitForClaimHolder(walletId: WalletIdOptions, paths: DownloadStatePaths): Promise<void> {
+  const deadline = Date.now() + DOWNLOAD_CONFIG.maxWaitMs;
 
-/**
- * Wait for the primary worker to complete the download
- */
-async function waitForDownloadCompletion(walletId: WalletIdOptions, paths: DownloadStatePaths): Promise<void> {
-  while (!isDownloadComplete(paths)) {
+  while (true) {
+    // eslint-disable-next-line no-console
+    console.info(`Waiting for another worker to download ${walletId}...`);
+    await sleep(DOWNLOAD_CONFIG.pollIntervalMs);
+
+    if (isDownloadComplete(paths)) return;
+
     if (hasDownloadError(paths)) {
       const errorMessage = getErrorMessage(paths) || 'Unknown error';
-      throw new Error(`Primary worker failed to download ${walletId}: ${errorMessage}`);
+      throw new Error(`Failed to download ${walletId}: ${errorMessage}`);
     }
 
-    // eslint-disable-next-line no-console
-    console.info(`Waiting for primary worker to download ${walletId}...`);
-    await sleep(DOWNLOAD_CONFIG.pollIntervalMs);
+    // Claim released without a result - fall back to the caller so it can claim the download
+    if (!isClaimHeld(paths)) return;
+
+    if (isClaimStale(paths)) {
+      // eslint-disable-next-line no-console
+      console.info(`Abandoned ${walletId} download detected, taking over...`);
+      releaseClaim(paths);
+      return;
+    }
+
+    if (Date.now() > deadline) {
+      throw new Error(
+        `Timed out after ${DOWNLOAD_CONFIG.maxWaitMs}ms waiting for another worker to download ${walletId}`,
+      );
+    }
   }
 }
 

--- a/src/downloader/github.ts
+++ b/src/downloader/github.ts
@@ -1,7 +1,11 @@
 import fs from 'fs';
 import { get } from 'https';
 import path from 'path';
+import { pipeline as pipelineCallback } from 'stream';
+import { promisify } from 'util';
 import { request } from './request';
+
+const pipeline = promisify(pipelineCallback);
 
 type GithubRelease = { downloadUrl: string; filename: string; tag: string };
 
@@ -66,16 +70,18 @@ export const getGithubRelease = (releasesUrl: string, version: string): Promise<
     });
   });
 
-export const downloadGithubRelease = (name: string, url: string, location: string): Promise<string> =>
-  new Promise(async (resolve) => {
-    if (!fs.existsSync(location)) {
-      fs.mkdirSync(location, { recursive: true });
-    }
-    const fileLocation = path.join(location, name);
-    const file = fs.createWriteStream(fileLocation);
-    const stream = await request(url);
-    stream.pipe(file);
-    stream.on('end', () => {
-      resolve(fileLocation);
-    });
-  });
+export const downloadGithubRelease = async (name: string, url: string, location: string): Promise<string> => {
+  if (!fs.existsSync(location)) {
+    fs.mkdirSync(location, { recursive: true });
+  }
+
+  const fileLocation = path.join(location, name);
+  const stream = await request(url);
+
+  // pipeline settles once the bytes have been flushed and the file is closed. Finishing any
+  // earlier - on the response's 'end', which only means the last chunk left the socket - hands
+  // back a file still short of its tail, and unzipping it fails with "Bad archive".
+  await pipeline(stream, fs.createWriteStream(fileLocation));
+
+  return fileLocation;
+};

--- a/src/downloader/request.ts
+++ b/src/downloader/request.ts
@@ -1,23 +1,31 @@
 import { IncomingMessage } from 'http';
 import { get } from 'https';
 
-export const request = (url: string): Promise<IncomingMessage> =>
-  new Promise((resolve) => {
-    const request = get(url, (response) => {
-      if (response.statusCode == 302) {
-        const redirectRequest = get(response.headers.location, resolve);
-        redirectRequest.on('error', (error) => {
-          // eslint-disable-next-line no-console
-          console.warn('request redirected error:', error.message);
-          throw error;
-        });
-      } else {
-        resolve(response);
+const MAX_REDIRECTS = 5;
+
+export const request = (url: string, redirectsLeft: number = MAX_REDIRECTS): Promise<IncomingMessage> =>
+  new Promise((resolve, reject) => {
+    const pending = get(url, (response) => {
+      const statusCode = response.statusCode ?? 0;
+      const location = response.headers.location;
+
+      // Release downloads redirect to a CDN, and the status used for it varies (301/302/307/308).
+      // Following only one of them leaves the redirect page itself to be written out as the
+      // download, which then fails to unzip.
+      if (statusCode >= 300 && statusCode < 400 && location) {
+        response.resume();
+
+        if (redirectsLeft === 0) return reject(new Error(`Too many redirects downloading ${url}`));
+        return resolve(request(location, redirectsLeft - 1));
       }
+
+      if (statusCode !== 200) {
+        response.resume();
+        return reject(new Error(`Request for ${url} failed with status ${statusCode}`));
+      }
+
+      resolve(response);
     });
-    request.on('error', (error) => {
-      // eslint-disable-next-line no-console
-      console.warn('request error:', error.message);
-      throw error;
-    });
+
+    pending.on('error', reject);
   });

--- a/test/3-dapp.spec.ts
+++ b/test/3-dapp.spec.ts
@@ -1,6 +1,12 @@
 import { CoinbaseWallet, MetaMaskWallet } from '../src';
 import { forCoinbase, forMetaMask } from './helpers/itForWallet';
-import { testWithWallet as test } from './helpers/walletTest';
+import { testWithWallet as test, useProjectAccount } from './helpers/walletTest';
+
+// These are the only tests that transact, so make sure the wallet is back on the account this
+// project owns - earlier specs share the same worker and move the wallet around
+test.beforeAll(async ({ wallet }, info) => {
+  await useProjectAccount(wallet, info);
+});
 
 // Adding manually only needed for Metamask since Coinbase does this automatically
 test.beforeAll(async ({ wallet }) => {

--- a/test/helpers/globalSetup.ts
+++ b/test/helpers/globalSetup.ts
@@ -1,0 +1,20 @@
+import { FullConfig } from '@playwright/test';
+import { OfficialOptions } from '../../src';
+import { getWalletType } from '../../src/wallets/wallets';
+
+/**
+ * Download every project's wallet extension before any worker starts.
+ *
+ * Workers can download on demand, but a cold cache then has to finish inside a test's timeout
+ * while the rest of the suite competes for the machine. Fetching up front keeps that cost out
+ * of the tests, and leaves each worker with nothing to do but read the cache.
+ */
+export default async function globalSetup(config: FullConfig): Promise<void> {
+  const downloads = config.projects.map(async (project) => {
+    const options = project.metadata as OfficialOptions;
+    const wallet = getWalletType(options.wallet);
+    if (wallet) await wallet.download(options);
+  });
+
+  await Promise.all(downloads);
+}

--- a/test/helpers/walletTest.ts
+++ b/test/helpers/walletTest.ts
@@ -1,15 +1,32 @@
-import { test as base } from '@playwright/test';
+import { test as base, TestInfo } from '@playwright/test';
 import { BrowserContext } from 'playwright-core';
 import { bootstrap, Dappwright, getWallet, OfficialOptions } from '../../src';
+
+type ProjectMetadata = OfficialOptions & { account?: string };
+
+/**
+ * Point the wallet at the account its project owns.
+ *
+ * Both projects import the same seed, so without this they drive the same address on the shared
+ * chain. The project runs on a single worker, which means every spec file shares one wallet -
+ * so a spec that switches accounts leaves the next one somewhere unexpected. Any file that
+ * transacts should call this to put the wallet back on its own account.
+ */
+export const useProjectAccount = async (wallet: Dappwright, info: TestInfo): Promise<void> => {
+  const { account } = info.project.metadata as ProjectMetadata;
+  if (account) await wallet.switchAccount(account);
+};
 
 export const testWithWallet = base.extend<{ wallet: Dappwright }, { walletContext: BrowserContext }>({
   walletContext: [
     async ({}, use, info) => {
-      const projectMetadata = info.project.metadata as OfficialOptions;
-      const [_, __, browserContext] = await bootstrap('', {
+      const { account: _account, ...projectMetadata } = info.project.metadata as ProjectMetadata;
+      const [wallet, __, browserContext] = await bootstrap('', {
         ...projectMetadata,
         headless: info.project.use.headless,
       });
+
+      await useProjectAccount(wallet, info);
 
       await use(browserContext);
       await browserContext.close();


### PR DESCRIPTION
dAppwright typically required projects to run one after the other because the downloader elected its downloading worker by TEST_PARALLEL_INDEX. Only one worker holds index 0, so as soon as two wallets were fetched at once, every worker for the second one waited on a download nobody had started. Workers now race for an atomic filesystem claim instead, heartbeating while they work so an abandoned claim can be taken over, and the previously unbounded wait has a ceiling.

With that in place the integration tests no longer require Coinbase project to depend on MetaMask, and each project runs on a single worker so the spec files sharing a chain account stay off each other's nonce.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally