### PR TITLE
fix(metamask): closes the duplicate wallet page left open after setup

### DIFF
--- a/.changeset/olive-jars-shave.md
+++ b/.changeset/olive-jars-shave.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+fix(metamask): closes the duplicate wallet page left open after setup

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -19,7 +19,7 @@ export async function launch(browserName: string, options: OfficialOptions): Pro
   const browserContext = await launchBrowser(wallet, userDataDir, officialOptions);
 
   const walletInstance = await getWallet(wallet.id, browserContext);
-  closeWalletSetupPopup(wallet.id, browserContext, walletInstance.page);
+  await closeWalletSetupPopup(wallet.id, browserContext, walletInstance.page);
 
   return {
     wallet: walletInstance,

--- a/src/wallets/wallets.ts
+++ b/src/wallets/wallets.ts
@@ -28,15 +28,40 @@ export const getWalletType = (id: WalletIdOptions): WalletTypes => {
   return walletType;
 };
 
-export const closeWalletSetupPopup = (
+export const closeWalletSetupPopup = async (
   id: WalletIdOptions,
   browserContext: BrowserContext,
   activeWalletPage: Page,
-): void => {
-  browserContext.on('page', async (page) => {
-    if (page !== activeWalletPage && page.url() === walletHomeUrl(id)) {
-      await page.close();
+): Promise<void> => {
+  const homeUrl = new URL(walletHomeUrl(id));
+
+  // The stray page settles on the same route as the wallet's own page (eg. home.html#/), so the
+  // hash can't tell them apart - but an approval popup is always a request, and carries either
+  // its own path (MetaMask's notification.html) or the request in a query string (Coinbase
+  // serves its popups from index.html). Match the home page, minus anything asking for input.
+  const isStrayWalletPage = (page: Page): boolean => {
+    try {
+      const pageUrl = new URL(page.url());
+      return pageUrl.origin === homeUrl.origin && pageUrl.pathname === homeUrl.pathname && !pageUrl.search;
+    } catch {
+      return false;
     }
+  };
+
+  const closeStrayPage = async (page: Page): Promise<void> => {
+    if (page === activeWalletPage || page.isClosed() || !isStrayWalletPage(page)) return;
+    await page.close().catch(() => undefined);
+  };
+
+  await Promise.all(browserContext.pages().map(closeStrayPage));
+
+  browserContext.on('page', async (page) => {
+    if (page === activeWalletPage) return;
+
+    // A newly opened page reports about:blank until it navigates. Checking the url straight off
+    // the event is why the stray page used to survive setup.
+    await page.waitForLoadState('domcontentloaded').catch(() => undefined);
+    await closeStrayPage(page);
   });
 };
 


### PR DESCRIPTION
**Short description of work done**

MetaMask navigates the browser's initial tab and also opens a home page of its own, leaving a second, unused wallet page behind. closeWalletSetupPopup was meant to clean that up but never fired: it checked page.url() straight off the 'page' event, and a newly opened page still reports about:blank until it navigates.

The check now waits for the page to settle, and matches on origin and pathname while ignoring anything carrying a query string. An approval popup is always a request and carries either its own path (MetaMask's notification.html) or the request in a query string (Coinbase serves its popups from the same path as its home page), so this leaves the popups that wallet actions depend on untouched.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally