### PR TITLE
chore: stops building a browser bundle

### DIFF
--- a/.changeset/olive-hoops-behave.md
+++ b/.changeset/olive-hoops-behave.md
@@ -1,0 +1,5 @@
+---
+'@tenkeylabs/dappwright': patch
+---
+
+chore: stops building a browser (UMD) bundle

--- a/package.json
+++ b/package.json
@@ -10,9 +10,8 @@
     "types": "./dist/index.d.ts",
     "require": "./dist/index.js",
     "import": "./dist/index.mjs",
-    "default": "./dist/index.modern.mjs"
+    "default": "./dist/index.mjs"
   },
-  "unpkg": "dist/index.umd.js",
   "files": [
     "dist/"
   ],
@@ -21,8 +20,8 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "microbundle --target node --tsconfig tsconfig.build.json --external os,https,zlib,stream,util,events,path,fs,module,fsevents,crypto,assert,process,tty,constants,readline,v8,node:module,@playwright/test",
-    "dev": "microbundle --target node --tsconfig tsconfig.build.json --external os,https,zlib,stream,util,events,path,fs,module,fsevents,crypto,assert,process,tty,constants,readline,v8,node:module,@playwright/test watch",
+    "build": "microbundle --target node --format esm,cjs --tsconfig tsconfig.build.json --external os,https,zlib,stream,util,events,path,fs,module,fsevents,crypto,assert,process,tty,constants,readline,v8,node:module,@playwright/test",
+    "dev": "microbundle --target node --format esm,cjs --tsconfig tsconfig.build.json --external os,https,zlib,stream,util,events,path,fs,module,fsevents,crypto,assert,process,tty,constants,readline,v8,node:module,@playwright/test watch",
     "lint": "yarn run lint:code && yarn run lint:unused",
     "lint:fix": "yarn run lint:code --fix",
     "lint:code": "eslint",


### PR DESCRIPTION
**Short description of work done**

microbundle emitted a UMD bundle alongside the node ones, and rollup warned that it depends on os, path, util, events, zlib, stream and https. Those come from our own source plus node-stream-zip, which is bundled rather than external. The library drives Playwright and Chromium, so it can only run under Node - a browser build of it cannot work, and nothing points at it except the unpkg entry, which is dropped here.

### PR Checklist

- [x] I have run linter locally
- [x] I have run unit and integration tests locally